### PR TITLE
Fix tag editor issues: disc number, album art deletion, genre dashes, save progress

### DIFF
--- a/Tunetag.xcodeproj/project.pbxproj
+++ b/Tunetag.xcodeproj/project.pbxproj
@@ -338,7 +338,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.Tunetag;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -383,7 +383,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.Tunetag;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/Tunetag/Localizable.xcstrings
+++ b/Tunetag/Localizable.xcstrings
@@ -1789,6 +1789,125 @@
         }
       }
     },
+    "TagEditor.RemoveAlbumArt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Album Art"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アルバムカバーを削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앨범 아트 제거"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa Ảnh Bìa Album"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除专辑封面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除專輯封面"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Albumcover entfernen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar portada del álbum"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer la pochette"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi copertina album"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover capa do álbum"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลบปกอัลบั้ม"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hapus Sampul Album"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Albüm Kapağını Kaldır"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń okładkę albumu"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة غلاف الألبوم"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Albumhoes verwijderen"
+          }
+        },
+        "ms": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alih Keluar Seni Album"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एल्बम आर्ट हटाएं"
+          }
+        }
+      }
+    },
     "TagEditor.SelectAlbumArt": {
       "extractionState": "manual",
       "localizations": {

--- a/Tunetag/Views/Tag Editor/FileHeaderSection.swift
+++ b/Tunetag/Views/Tag Editor/FileHeaderSection.swift
@@ -13,6 +13,7 @@ struct FileHeaderSection: View {
     @State var filename: String
     @Binding var albumArt: Data?
     @Binding var selectedAlbumArt: PhotosPickerItem?
+    @Binding var isAlbumArtRemoved: Bool
     @State var showsPhotosPicker: Bool = true
 
     var body: some View {
@@ -42,14 +43,30 @@ struct FileHeaderSection: View {
                         .textCase(.none)
                         .foregroundStyle(.primary)
                     if showsPhotosPicker {
-                        PhotosPicker(selection: $selectedAlbumArt,
-                                     matching: .images,
-                                     photoLibrary: .shared()) {
-                            Text("TagEditor.SelectAlbumArt")
-                                .bold()
+                        HStack(spacing: 8.0) {
+                            PhotosPicker(selection: $selectedAlbumArt,
+                                         matching: .images,
+                                         photoLibrary: .shared()) {
+                                Text("TagEditor.SelectAlbumArt")
+                                    .bold()
+                            }
+                                         .clipShape(RoundedRectangle(cornerRadius: 99))
+                                         .buttonStyle(.borderedProminent)
+                            if albumArt != nil {
+                                Button(role: .destructive) {
+                                    selectedAlbumArt = nil
+                                    albumArt = nil
+                                    isAlbumArtRemoved = true
+                                } label: {
+                                    Label("TagEditor.RemoveAlbumArt", systemImage: "trash")
+                                        .labelStyle(.iconOnly)
+                                        .bold()
+                                }
+                                .clipShape(RoundedRectangle(cornerRadius: 99))
+                                .buttonStyle(.bordered)
+                                .tint(.red)
+                            }
                         }
-                                     .clipShape(RoundedRectangle(cornerRadius: 99))
-                                     .buttonStyle(.borderedProminent)
                     }
                 }
             }

--- a/Tunetag/Views/Tag Editor/TagDataSection.swift
+++ b/Tunetag/Views/Tag Editor/TagDataSection.swift
@@ -73,7 +73,7 @@ struct TagDataSection: View {
         }
         .onReceive(Just(tagData.genre)) { _ in
             if let genre = tagData.genre {
-                tagData.genre = genre.filter({ $0.isLetter || $0.isWhitespace })
+                tagData.genre = genre.filter({ $0.isLetter || $0.isWhitespace || $0 == "-" })
             }
         }
         .onReceive(Just(tagData.discNumber)) { _ in

--- a/Tunetag/Views/Tag Editor/TagEditorView.swift
+++ b/Tunetag/Views/Tag Editor/TagEditorView.swift
@@ -19,7 +19,10 @@ struct TagEditorView: View {
     @State var tags: [FSFile: ID3Tag] = [:]
     @State var tagData = Tag()
     @State var selectedAlbumArt: PhotosPickerItem?
+    @State var isAlbumArtRemoved: Bool = false
     @State var saveState: SaveState = .notSaved
+    @State var savedFileCount: Int = 0
+    @State var totalFileCount: Int = 0
     @FocusState var focusedField: FocusedField?
 
     // Support for iOS 16
@@ -36,7 +39,8 @@ struct TagEditorView: View {
             if files.count == 1 {
                 FileHeaderSection(filename: files[0].name,
                                   albumArt: $tagData.albumArt,
-                                  selectedAlbumArt: $selectedAlbumArt)
+                                  selectedAlbumArt: $selectedAlbumArt,
+                                  isAlbumArtRemoved: $isAlbumArtRemoved)
                 if #available(iOS 17.0, *) {
                     TagDataSection(tagData: $tagData, focusedField: $focusedField)
                         .popoverTip(AvailableTokensTip(), arrowEdge: .top)
@@ -46,7 +50,8 @@ struct TagEditorView: View {
             } else {
                 FileHeaderSection(filename: NSLocalizedString("BatchEdit.MultipleFiles", comment: ""),
                                   albumArt: $tagData.albumArt,
-                                  selectedAlbumArt: $selectedAlbumArt)
+                                  selectedAlbumArt: $selectedAlbumArt,
+                                  isAlbumArtRemoved: $isAlbumArtRemoved)
                 if #available(iOS 17.0, *) {
                     TagDataSection(tagData: $tagData, focusedField: $focusedField,
                                    placeholder: NSLocalizedString("BatchEdit.Keep", comment: ""))
@@ -88,10 +93,27 @@ struct TagEditorView: View {
                         .bold()
                         .frame(maxWidth: .infinity)
                 case .saving:
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                        .padding(.all, 8.0)
-                        .tint(.white)
+                    if totalFileCount > 1 {
+                        VStack(spacing: 4.0) {
+                            ProgressView(value: Double(savedFileCount),
+                                         total: Double(max(totalFileCount, 1)))
+                                .progressViewStyle(.linear)
+                                .tint(.white)
+                            Text("\(savedFileCount) / \(totalFileCount)")
+                                .font(.caption)
+                                .bold()
+                                .foregroundStyle(.white)
+                                .monospacedDigit()
+                        }
+                        .padding([.top, .bottom], 8.0)
+                        .padding([.leading, .trailing], 16.0)
+                        .frame(maxWidth: .infinity)
+                    } else {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .padding(.all, 8.0)
+                            .tint(.white)
+                    }
                 case .saved:
                     Image(systemName: "checkmark")
                         .font(.body)
@@ -118,6 +140,7 @@ struct TagEditorView: View {
                 if let selectedAlbumArt = selectedAlbumArt,
                     let data = try? await selectedAlbumArt.loadTransferable(type: Data.self) {
                     tagData.albumArt = data
+                    isAlbumArtRemoved = false
                 }
             }
         }
@@ -162,9 +185,16 @@ struct TagEditorView: View {
         if let tagCombined = tagCombined {
             tagData = Tag(from: tagCombined)
         }
+        isAlbumArtRemoved = false
     }
 
     func saveAllTagData() async {
+        await MainActor.run {
+            withAnimation(.snappy.speed(2)) {
+                savedFileCount = 0
+                totalFileCount = files.count
+            }
+        }
         _ = await withTaskGroup(of: Bool.self, returning: [Bool].self) { group in
             for file in files {
                 group.addTask {
@@ -175,6 +205,11 @@ struct TagEditorView: View {
             var saveStates: [Bool] = []
             for await result in group {
                 saveStates.append(result)
+                await MainActor.run {
+                    withAnimation(.snappy.speed(2)) {
+                        savedFileCount += 1
+                    }
+                }
             }
             return saveStates
         }
@@ -238,15 +273,17 @@ struct TagEditorView: View {
                 tagBuilder = tagBuilder.composer(frame: id3Frame(value, referencing: file))
             }
             // Build disc number frame
-            if let frame = id3Frame(tagData.discNumber, returns: ID3FramePartOfTotal.self) {
+            if let frame = id3Frame(tagData.discNumber, returns: ID3FramePartOfTotal.self), frame.part != -999999 {
                 tagBuilder = tagBuilder.discPosition(frame: frame)
-            } else if let tag = tag, let value = ID3TagContentReader(id3Tag: tag).discPosition() {
+            } else if tagData.discNumber == nil, let tag = tag,
+                      let value = ID3TagContentReader(id3Tag: tag).discPosition() {
                 tagBuilder = tagBuilder.discPosition(frame: id3Frame(value.position, total: value.total))
             }
             // Build album art frame
             if let frame = id3Frame(tagData.albumArt, type: .frontCover) {
                 tagBuilder = tagBuilder.attachedPicture(pictureType: .frontCover, frame: frame)
-            } else if let tag = tag, let albumArt = ID3TagContentReader(id3Tag: tag).attachedPictures()
+            } else if !isAlbumArtRemoved, let tag = tag,
+                      let albumArt = ID3TagContentReader(id3Tag: tag).attachedPictures()
                 .first(where: { $0.type == .frontCover }),
                       let frame = id3Frame(albumArt.picture, type: .frontCover) {
                 tagBuilder = tagBuilder


### PR DESCRIPTION
## Summary

Addresses the four open issues in the tracker:

- **#15 — Leave Disc Number field blank:** Cleared disc numbers were being written out as the `-999999` sentinel and read back as `999999`. Now the disc number frame uses the same guard as the track frame, skipping the write entirely when the value is blank and only carrying over the original tag when the editor field is `nil`.
- **#14 — Album image can be changed but can't be deleted:** Added a destructive trash button next to the "Select Album Art" button in `FileHeaderSection`. It clears the in-memory artwork and sets a new `isAlbumArtRemoved` flag so the save path skips falling back to the existing attached picture. Picking a new photo resets the flag.
- **#11 — Support entering dashes in genre field:** The `onReceive` filter on `tagData.genre` now also permits `-` alongside letters and whitespace.
- **#5 — Implement progress view when saving tags:** When saving more than one file, the save button now displays a linear `ProgressView` with an `X / Y` counter that advances as each file completes its `TaskGroup` save. Single-file saves keep the existing spinner.

Also added the new `TagEditor.RemoveAlbumArt` string to `Localizable.xcstrings` across all shipped locales.

## Test plan

- [ ] Open a single MP3, clear the Disc Number field, save, reopen — field should stay blank, no `999999`.
- [ ] Open an MP3 with album art, tap the new trash button, save, reopen — album art should be gone.
- [ ] Pick a new image after removing art, save, reopen — new art should persist.
- [ ] Enter a genre with dashes (e.g. `rock-pop`), save, reopen — dashes preserved.
- [ ] Batch edit 5+ files, tap Save — progress bar fills as each file finishes, `X / Y` counter updates.
