### PR TITLE
Migrate to SFBAudioEngine and bump to 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 xcuserdata/
 .DS_Store
+Tunetag/Licenses.plist

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Tunetag
 
-A batch MP3 tag editor built for iOS.
+A batch audio tag editor built for iOS.
 
 **Download: [App Store](https://apps.apple.com/app/id6464678747)**
 
 ## Development
 
 ### What works
-- Viewing and opening MP3 files
-- Viewing, editing, and saving ID3 tags in MP3 files (including album art!)
-- Batch editing ID3 tags
-- Using tokens to fill out ID3 tags using existing data (such as filenames)
+- Viewing and opening audio files (MP3, M4A/MP4, FLAC, Ogg Vorbis/Opus/Speex/FLAC, WAV, AIFF, Monkey's Audio, Musepack, WavPack, Shorten, True Audio, DSDIFF, DSF, and more — powered by [SFBAudioEngine](https://github.com/sbooth/SFBAudioEngine))
+- Viewing, editing, and saving audio tags (including album art!)
+- Batch editing audio tags
+- Using tokens to fill out audio tags using existing data (such as filenames)

--- a/Scripts/generate_licenses.sh
+++ b/Scripts/generate_licenses.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+
+RESOLVED="${SRCROOT}/Tunetag.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+CHECKOUTS="${BUILD_DIR%Build/*}SourcePackages/checkouts"
+OUTPUT="${SRCROOT}/Tunetag/Licenses.plist"
+
+if [ ! -f "$RESOLVED" ]; then
+    echo "error: Package.resolved not found at $RESOLVED"
+    exit 1
+fi
+
+if [ ! -d "$CHECKOUTS" ]; then
+    echo "error: SourcePackages/checkouts not found at $CHECKOUTS"
+    exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+PIN_COUNT=$(plutil -extract pins raw -o - "$RESOLVED")
+
+ENTRIES_TSV=$(mktemp)
+trap 'rm -f "$ENTRIES_TSV"' EXIT
+
+for ((i = 0; i < PIN_COUNT; i++)); do
+    LOCATION=$(plutil -extract "pins.$i.location" raw -o - "$RESOLVED")
+    NAME=${LOCATION%/}
+    NAME=${NAME##*/}
+    NAME=${NAME%.git}
+    [ -z "$NAME" ] && continue
+
+    ACTUAL_DIR=""
+    NAME_LOWER=$(printf '%s' "$NAME" | tr '[:upper:]' '[:lower:]')
+    for entry in "$CHECKOUTS"/*; do
+        [ -d "$entry" ] || continue
+        BASE=$(basename "$entry")
+        BASE_LOWER=$(printf '%s' "$BASE" | tr '[:upper:]' '[:lower:]')
+        if [ "$BASE_LOWER" = "$NAME_LOWER" ]; then
+            ACTUAL_DIR=$BASE
+            break
+        fi
+    done
+
+    if [ -z "$ACTUAL_DIR" ]; then
+        echo "warning: no checkout directory for $NAME"
+        continue
+    fi
+
+    LICENSE_PATHS=()
+    while IFS= read -r path; do
+        LICENSE_PATHS+=("$path")
+    done < <(find "$CHECKOUTS/$ACTUAL_DIR" -maxdepth 1 -type f \
+        \( -iname 'LICENSE' -o -iname 'LICENSE.*' -o -iname 'LICENSE-*' \) | sort)
+
+    if [ "${#LICENSE_PATHS[@]}" -eq 0 ]; then
+        echo "warning: no LICENSE file found for $NAME"
+        continue
+    fi
+
+    SORT_KEY=$(printf '%s' "$ACTUAL_DIR" | tr '[:upper:]' '[:lower:]')
+    JOINED_PATHS=$(IFS='|'; printf '%s' "${LICENSE_PATHS[*]}")
+    printf '%s\t%s\t%s\n' "$SORT_KEY" "$ACTUAL_DIR" "$JOINED_PATHS" >> "$ENTRIES_TSV"
+done
+
+SORTED_TSV=$(mktemp)
+sort -t $'\t' -k1,1 "$ENTRIES_TSV" > "$SORTED_TSV"
+
+echo '{}' | plutil -convert xml1 -o "$OUTPUT" -
+plutil -insert dependencies -array "$OUTPUT"
+
+INDEX=0
+COUNT=0
+while IFS=$'\t' read -r _ name paths; do
+    IFS='|' read -r -a path_array <<< "$paths"
+
+    if [ "${#path_array[@]}" -gt 1 ]; then
+        TEXT=""
+        for path in "${path_array[@]}"; do
+            BODY=$(tr -d '\000-\010\013\014\016-\037' < "$path")
+            if [ -n "$TEXT" ]; then
+                TEXT+=$'\n\n'
+            fi
+            TEXT+="--- $(basename "$path") ---"$'\n'"$BODY"
+        done
+    else
+        TEXT=$(tr -d '\000-\010\013\014\016-\037' < "${path_array[0]}")
+    fi
+
+    plutil -insert "dependencies.$INDEX" -dictionary "$OUTPUT"
+    plutil -insert "dependencies.$INDEX.name" -string "$name" "$OUTPUT"
+    plutil -insert "dependencies.$INDEX.licenseText" -string "$TEXT" "$OUTPUT"
+
+    INDEX=$((INDEX + 1))
+    COUNT=$((COUNT + 1))
+done < "$SORTED_TSV"
+
+rm -f "$SORTED_TSV"
+
+echo "Generated $OUTPUT with $COUNT entries"

--- a/Tunetag.xcodeproj/project.pbxproj
+++ b/Tunetag.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		E436724B2AC859F60016B57C /* Komponents in Frameworks */ = {isa = PBXBuildFile; productRef = E436724A2AC859F60016B57C /* Komponents */; };
 		E4B206EC2D340C9D004CF4A1 /* SFBAudioEngine in Frameworks */ = {isa = PBXBuildFile; productRef = E4B206EB2D340C9D004CF4A1 /* SFBAudioEngine */; };
 /* End PBXBuildFile section */
 
@@ -34,7 +33,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E436724B2AC859F60016B57C /* Komponents in Frameworks */,
 				E4B206EC2D340C9D004CF4A1 /* SFBAudioEngine in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -79,7 +77,6 @@
 			);
 			name = Tunetag;
 			packageProductDependencies = (
-				E436724A2AC859F60016B57C /* Komponents */,
 				E4B206EB2D340C9D004CF4A1 /* SFBAudioEngine */,
 			);
 			productName = Tunetag;
@@ -129,7 +126,6 @@
 			);
 			mainGroup = E432A6FE2AA9FD5E0043BCC9;
 			packageReferences = (
-				E43672492AC859F60016B57C /* XCRemoteSwiftPackageReference "Komponents" */,
 				E4B206EA2D340C9D004CF4A1 /* XCRemoteSwiftPackageReference "SFBAudioEngine" */,
 			);
 			productRefGroup = E432A7082AA9FD5E0043BCC9 /* Products */;
@@ -419,14 +415,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		E43672492AC859F60016B57C /* XCRemoteSwiftPackageReference "Komponents" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/katagaki/Komponents";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 		E4B206EA2D340C9D004CF4A1 /* XCRemoteSwiftPackageReference "SFBAudioEngine" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sbooth/SFBAudioEngine";
@@ -438,11 +426,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		E436724A2AC859F60016B57C /* Komponents */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E43672492AC859F60016B57C /* XCRemoteSwiftPackageReference "Komponents" */;
-			productName = Komponents;
-		};
 		E4B206EB2D340C9D004CF4A1 /* SFBAudioEngine */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E4B206EA2D340C9D004CF4A1 /* XCRemoteSwiftPackageReference "SFBAudioEngine" */;

--- a/Tunetag.xcodeproj/project.pbxproj
+++ b/Tunetag.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		E436724B2AC859F60016B57C /* Komponents in Frameworks */ = {isa = PBXBuildFile; productRef = E436724A2AC859F60016B57C /* Komponents */; };
-		E4B206EC2D340C9D004CF4A1 /* ID3TagEditor in Frameworks */ = {isa = PBXBuildFile; productRef = E4B206EB2D340C9D004CF4A1 /* ID3TagEditor */; };
+		E4B206EC2D340C9D004CF4A1 /* SFBAudioEngine in Frameworks */ = {isa = PBXBuildFile; productRef = E4B206EB2D340C9D004CF4A1 /* SFBAudioEngine */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,7 +35,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E436724B2AC859F60016B57C /* Komponents in Frameworks */,
-				E4B206EC2D340C9D004CF4A1 /* ID3TagEditor in Frameworks */,
+				E4B206EC2D340C9D004CF4A1 /* SFBAudioEngine in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -80,7 +80,7 @@
 			name = Tunetag;
 			packageProductDependencies = (
 				E436724A2AC859F60016B57C /* Komponents */,
-				E4B206EB2D340C9D004CF4A1 /* ID3TagEditor */,
+				E4B206EB2D340C9D004CF4A1 /* SFBAudioEngine */,
 			);
 			productName = Tunetag;
 			productReference = E432A7072AA9FD5E0043BCC9 /* Tunetag.app */;
@@ -130,7 +130,7 @@
 			mainGroup = E432A6FE2AA9FD5E0043BCC9;
 			packageReferences = (
 				E43672492AC859F60016B57C /* XCRemoteSwiftPackageReference "Komponents" */,
-				E4B206EA2D340C9D004CF4A1 /* XCRemoteSwiftPackageReference "ID3TagEditor" */,
+				E4B206EA2D340C9D004CF4A1 /* XCRemoteSwiftPackageReference "SFBAudioEngine" */,
 			);
 			productRefGroup = E432A7082AA9FD5E0043BCC9 /* Products */;
 			projectDirPath = "";
@@ -338,7 +338,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.Tunetag;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -383,7 +383,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsubuzaki.Tunetag;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -427,12 +427,12 @@
 				kind = branch;
 			};
 		};
-		E4B206EA2D340C9D004CF4A1 /* XCRemoteSwiftPackageReference "ID3TagEditor" */ = {
+		E4B206EA2D340C9D004CF4A1 /* XCRemoteSwiftPackageReference "SFBAudioEngine" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/chicio/ID3TagEditor";
+			repositoryURL = "https://github.com/sbooth/SFBAudioEngine";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 0.12.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -443,10 +443,10 @@
 			package = E43672492AC859F60016B57C /* XCRemoteSwiftPackageReference "Komponents" */;
 			productName = Komponents;
 		};
-		E4B206EB2D340C9D004CF4A1 /* ID3TagEditor */ = {
+		E4B206EB2D340C9D004CF4A1 /* SFBAudioEngine */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = E4B206EA2D340C9D004CF4A1 /* XCRemoteSwiftPackageReference "ID3TagEditor" */;
-			productName = ID3TagEditor;
+			package = E4B206EA2D340C9D004CF4A1 /* XCRemoteSwiftPackageReference "SFBAudioEngine" */;
+			productName = SFBAudioEngine;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tunetag.xcodeproj/project.pbxproj
+++ b/Tunetag.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E432A7162AA9FD5F0043BCC9 /* Build configuration list for PBXNativeTarget "Tunetag" */;
 			buildPhases = (
+				E432A7502AAA31820043BCC9 /* Generate Licenses */,
 				E432A7032AA9FD5E0043BCC9 /* Sources */,
 				E432A7042AA9FD5E0043BCC9 /* Frameworks */,
 				E432A7052AA9FD5E0043BCC9 /* Resources */,
@@ -165,6 +166,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		E432A7502AAA31820043BCC9 /* Generate Licenses */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Tunetag.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved",
+				"$(SRCROOT)/Scripts/generate_licenses.sh",
+			);
+			name = "Generate Licenses";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/Tunetag/Licenses.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Scripts/generate_licenses.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Tunetag.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tunetag.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -92,15 +92,6 @@
       }
     },
     {
-      "identity" : "komponents",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/katagaki/Komponents",
-      "state" : {
-        "branch" : "main",
-        "revision" : "93f484d6f2cef9c179387fcca2b2048413f9f0a6"
-      }
-    },
-    {
       "identity" : "lame-binary-xcframework",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sbooth/lame-binary-xcframework",

--- a/Tunetag.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tunetag.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,21 +2,21 @@
   "originHash" : "37f8517d9cd34a993adf1b4a453cfb2e82fdbbd760c91a285d2486fe3a40625f",
   "pins" : [
     {
-      "identity" : "id3tageditor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/chicio/ID3TagEditor",
-      "state" : {
-        "revision" : "e08dd0118d4418900ac3b8f621a6b3d24ae5416f",
-        "version" : "5.5.0"
-      }
-    },
-    {
       "identity" : "komponents",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/katagaki/Komponents",
       "state" : {
         "branch" : "main",
         "revision" : "93f484d6f2cef9c179387fcca2b2048413f9f0a6"
+      }
+    },
+    {
+      "identity" : "sfbaudioengine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/SFBAudioEngine",
+      "state" : {
+        "revision" : "10670eb58f9acc0e5ac2907dc744a78ade2597cd",
+        "version" : "0.12.1"
       }
     }
   ],

--- a/Tunetag.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tunetag.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,96 @@
 {
-  "originHash" : "37f8517d9cd34a993adf1b4a453cfb2e82fdbbd760c91a285d2486fe3a40625f",
+  "originHash" : "ac9cd0e64c7b73144fe41e9a1ab16da595b7edcdbcf9fe5d8c5463590b6aca83",
   "pins" : [
+    {
+      "identity" : "avfaudioextensions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/AVFAudioExtensions",
+      "state" : {
+        "revision" : "276deda6780b974be0d3dacf1bb0a890754b9e1b",
+        "version" : "0.5.1"
+      }
+    },
+    {
+      "identity" : "cdumb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/CDUMB",
+      "state" : {
+        "revision" : "0cceb710cad35b9aaf5bb6b65faf71436b6aa7c3",
+        "version" : "2.0.3"
+      }
+    },
+    {
+      "identity" : "cspeex",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/CSpeex",
+      "state" : {
+        "revision" : "ba33fd93d54d8e7fc93b8a1d27991e756bac7345",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "cxxaudioringbuffer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/CXXAudioRingBuffer",
+      "state" : {
+        "revision" : "95052b6bd4ccf192e2f0983d401224e7a4921e39",
+        "version" : "0.1.1"
+      }
+    },
+    {
+      "identity" : "cxxdispatchsemaphore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/CXXDispatchSemaphore",
+      "state" : {
+        "revision" : "cd267c1dffae0e132abe7b63fcee1e1fe357f23d",
+        "version" : "0.4.1"
+      }
+    },
+    {
+      "identity" : "cxxmonkeysaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/CXXMonkeysAudio",
+      "state" : {
+        "revision" : "79cafc4dfccff8b9d3065cbf198f6e171a9409c3",
+        "version" : "12.13.0"
+      }
+    },
+    {
+      "identity" : "cxxringbuffer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/CXXRingBuffer",
+      "state" : {
+        "revision" : "8d859aa73d115273afcebe754b22bf50d3ea0621",
+        "version" : "0.6.1"
+      }
+    },
+    {
+      "identity" : "cxxtaglib",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/CXXTagLib",
+      "state" : {
+        "revision" : "a243fefb04d56eeade7669b4ec90dc2997089fbb",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "cxxunfairlock",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/CXXUnfairLock",
+      "state" : {
+        "revision" : "d134022b339567958b3a941dfa3cd079d31f1030",
+        "version" : "0.3.1"
+      }
+    },
+    {
+      "identity" : "flac-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/flac-binary-xcframework",
+      "state" : {
+        "revision" : "9005dc2cd455765fb6824eb215c9703429bbe8ff",
+        "version" : "0.2.0"
+      }
+    },
     {
       "identity" : "komponents",
       "kind" : "remoteSourceControl",
@@ -11,12 +101,93 @@
       }
     },
     {
+      "identity" : "lame-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/lame-binary-xcframework",
+      "state" : {
+        "revision" : "07703e040231d50f2e7f160c670f356f129a00e4",
+        "version" : "0.1.2"
+      }
+    },
+    {
+      "identity" : "mpc-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/mpc-binary-xcframework",
+      "state" : {
+        "revision" : "de4b45fa64ed88467806c50217e9da7032a99d80",
+        "version" : "0.1.2"
+      }
+    },
+    {
+      "identity" : "mpg123-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/mpg123-binary-xcframework",
+      "state" : {
+        "revision" : "acc2c651cbd8fff8bc8cdeb4faf14b35ba81adee",
+        "version" : "0.3.1"
+      }
+    },
+    {
+      "identity" : "ogg-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/ogg-binary-xcframework",
+      "state" : {
+        "revision" : "48cbf24e7fb5d329b1f5e24cd2e5b048585ff770",
+        "version" : "0.1.3"
+      }
+    },
+    {
+      "identity" : "opus-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/opus-binary-xcframework",
+      "state" : {
+        "revision" : "8e23828b9d88f0ff1ff2d7c4bcb65739a4bdeff8",
+        "version" : "0.3.0"
+      }
+    },
+    {
       "identity" : "sfbaudioengine",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sbooth/SFBAudioEngine",
       "state" : {
         "revision" : "10670eb58f9acc0e5ac2907dc744a78ade2597cd",
         "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "sndfile-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/sndfile-binary-xcframework",
+      "state" : {
+        "revision" : "52f73460dc04ba789ad3007ad004faa328b732dd",
+        "version" : "0.1.2"
+      }
+    },
+    {
+      "identity" : "tta-cpp-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/tta-cpp-binary-xcframework",
+      "state" : {
+        "revision" : "b68cf8a127936434cae93aa2c613d4b47eb34de4",
+        "version" : "0.1.2"
+      }
+    },
+    {
+      "identity" : "vorbis-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/vorbis-binary-xcframework",
+      "state" : {
+        "revision" : "842020eabcebe410e698c68545d6597b2d232e51",
+        "version" : "0.1.2"
+      }
+    },
+    {
+      "identity" : "wavpack-binary-xcframework",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sbooth/wavpack-binary-xcframework",
+      "state" : {
+        "revision" : "c8c2a9f930349a7209e14f6e5667fc5cc38b6c4b",
+        "version" : "0.2.0"
       }
     }
   ],

--- a/Tunetag/Classes/SceneDelegate.swift
+++ b/Tunetag/Classes/SceneDelegate.swift
@@ -3,6 +3,7 @@
 //  Tunetag
 //
 
+import SFBAudioEngine
 import StoreKit
 import SwiftUI
 import TipKit
@@ -24,7 +25,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         configureTipKit()
         promptReviewIfNeeded(in: windowScene)
 
-        let browser = UIDocumentBrowserViewController(forOpening: [.mp3])
+        let browser = UIDocumentBrowserViewController(forOpening: [.audio])
         browser.allowsDocumentCreation = false
         browser.allowsPickingMultipleItems = true
         browser.shouldShowFileExtensions = true
@@ -106,7 +107,7 @@ extension SceneDelegate: UIDocumentBrowserViewControllerDelegate {
         for url in documentURLs {
             _ = url.startAccessingSecurityScopedResource()
             accessedURLs.append(url)
-            if url.pathExtension.lowercased() == "mp3" {
+            if AudioFile.handlesPaths(withExtension: url.pathExtension.lowercased()) {
                 files.append(FSFile(name: url.lastPathComponent,
                                     path: url.path(percentEncoded: false),
                                     isArbitrarilyLoadedFromDragAndDrop: true))

--- a/Tunetag/Info.plist
+++ b/Tunetag/Info.plist
@@ -6,12 +6,20 @@
 	<array>
 		<dict>
 			<key>CFBundleTypeName</key>
-			<string>MP3 Audio</string>
+			<string>Audio File</string>
 			<key>LSHandlerRank</key>
 			<string>Alternate</string>
 			<key>LSItemContentTypes</key>
 			<array>
+				<string>public.audio</string>
 				<string>public.mp3</string>
+				<string>public.mpeg-4-audio</string>
+				<string>public.aiff-audio</string>
+				<string>public.aifc-audio</string>
+				<string>com.microsoft.waveform-audio</string>
+				<string>org.xiph.flac</string>
+				<string>org.xiph.ogg-audio</string>
+				<string>org.xiph.opus</string>
 			</array>
 		</dict>
 	</array>

--- a/Tunetag/Localizable.xcstrings
+++ b/Tunetag/Localizable.xcstrings
@@ -1,3341 +1,3352 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "BatchEdit.Keep": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Don't Change"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%lld / %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld / %2$lld"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "Alert.NoMP3Files.Message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التحديد لا يحتوي على أي ملفات MP3."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "変更しない"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Auswahl enthält keine MP3-Dateien."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "변경 안 함"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The selection does not contain any MP3 files."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Không Thay Đổi"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La selección no contiene archivos MP3."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不更改"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La sélection ne contient aucun fichier MP3."
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不更改"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "चयन में कोई MP3 फ़ाइल नहीं है।"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nicht ändern"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilihan tidak berisi file MP3."
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No cambiar"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La selezione non contiene file MP3."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ne pas modifier"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択された項目にMP3ファイルが含まれていません。"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Non modificare"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 항목에 MP3 파일이 없습니다."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Não alterar"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilihan tidak mengandungi sebarang fail MP3."
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่เปลี่ยนแปลง"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De selectie bevat geen MP3-bestanden."
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jangan Ubah"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaznaczenie nie zawiera plików MP3."
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Değiştirme"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A seleção não contém nenhum arquivo MP3."
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nie zmieniaj"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "รายการที่เลือกไม่มีไฟล์ MP3"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عدم التغيير"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seçim herhangi bir MP3 dosyası içermiyor."
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Niet wijzigen"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lựa chọn không chứa tệp MP3 nào."
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jangan Ubah"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所选内容不包含任何MP3文件。"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बदलें नहीं"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所選內容不包含任何MP3檔案。"
           }
         }
       }
     },
-    "BatchEdit.MultipleFiles": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Multiple Files"
+    "Alert.NoMP3Files.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لم يتم العثور على ملفات MP3"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "複数のファイル"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine MP3-Dateien gefunden"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "여러 파일"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No MP3 Files Found"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhiều Tệp"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron archivos MP3"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "多个文件"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun fichier MP3 trouvé"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "多個檔案"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कोई MP3 फ़ाइल नहीं मिली"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mehrere Dateien"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak Ada File MP3 Ditemukan"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Varios archivos"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun file MP3 trovato"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fichiers multiples"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MP3ファイルが見つかりません"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File multipli"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MP3 파일을 찾을 수 없음"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vários arquivos"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiada Fail MP3 Ditemui"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หลายไฟล์"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geen MP3-bestanden gevonden"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beberapa File"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie znaleziono plików MP3"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Birden Fazla Dosya"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum arquivo MP3 encontrado"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wiele plików"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ไม่พบไฟล์ MP3"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ملفات متعددة"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MP3 Dosyası Bulunamadı"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Meerdere bestanden"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không tìm thấy tệp MP3"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Berbilang Fail"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到MP3文件"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एकाधिक फ़ाइलें"
-          }
-        }
-      }
-    },
-    "katagaki/Tunetag": {
-      "shouldTranslate": false
-    },
-    "More.Attributions": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attributions"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "著者権表記"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "저작자 표시"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ghi Công"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "版权声明"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "版權聲明"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Danksagungen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atribuciones"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attributions"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attribuzioni"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atribuições"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เครดิต"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atribusi"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atıflar"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Podziękowania"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإسنادات"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vermeldingen"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atribusi"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "श्रेय"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到MP3檔案"
           }
         }
       }
     },
-    "More.GitHub": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source Code"
+    "BatchEdit.Keep" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عدم التغيير"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソースコード"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht ändern"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "소스 코드"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don't Change"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mã Nguồn"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No cambiar"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "源代码"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ne pas modifier"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "原始碼"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "बदलें नहीं"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quellcode"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jangan Ubah"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Código fuente"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non modificare"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Code source"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変更しない"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Codice sorgente"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "변경 안 함"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Código-fonte"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jangan Ubah"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ซอร์สโค้ด"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niet wijzigen"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kode Sumber"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie zmieniaj"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kaynak Kodu"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não alterar"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kod źródłowy"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ไม่เปลี่ยนแปลง"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الشيفرة المصدرية"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Değiştirme"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Broncode"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không Thay Đổi"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kod Sumber"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不更改"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सोर्स कोड"
-          }
-        }
-      }
-    },
-    "Shared.Done": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完了"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "완료"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xong"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完成"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完成"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fertig"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Listo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminé"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fatto"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Concluído"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เสร็จ"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selesai"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bitti"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gotowe"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تم"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gereed"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selesai"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पूर्ण"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不更改"
           }
         }
       }
     },
-    "Shared.Save": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save"
+    "BatchEdit.MultipleFiles" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ملفات متعددة"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehrere Dateien"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "저장"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Multiple Files"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lưu"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Varios archivos"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fichiers multiples"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "儲存"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एकाधिक फ़ाइलें"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sichern"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beberapa File"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guardar"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "File multipli"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enregistrer"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複数のファイル"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Salva"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여러 파일"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Salvar"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berbilang Fail"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "บันทึก"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meerdere bestanden"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Simpan"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiele plików"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kaydet"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vários arquivos"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zapisz"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "หลายไฟล์"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حفظ"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Birden Fazla Dosya"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bewaar"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhiều Tệp"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Simpan"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多个文件"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सहेजें"
-          }
-        }
-      }
-    },
-    "Tag.Album": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アルバム"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "앨범"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "专辑"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "專輯"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Álbum"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Álbum"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อัลบั้ม"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Albüm"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الألبوم"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एल्बम"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "多個檔案"
           }
         }
       }
     },
-    "Tag.AlbumArtist": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album Artist"
+    "katagaki/Tunetag" : {
+      "shouldTranslate" : false
+    },
+    "More.Attributions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الإسنادات"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アルバムアーティスト"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danksagungen"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "앨범 아티스트"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attributions"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nghệ Sĩ Album"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atribuciones"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "专辑艺人"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attributions"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "專輯藝人"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "श्रेय"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Album-Interpret"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atribusi"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artista del álbum"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attribuzioni"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artiste de l'album"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "著者権表記"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artista dell'album"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저작자 표시"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artista do álbum"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atribusi"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ศิลปินอัลบั้ม"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vermeldingen"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artis Album"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podziękowania"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Albüm Sanatçısı"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atribuições"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wykonawca albumu"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เครดิต"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فنان الألبوم"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atıflar"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Albumartiest"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ghi Công"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artis Album"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版权声明"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एल्बम कलाकार"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版權聲明"
           }
         }
       }
     },
-    "Tag.Artist": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artist"
+    "More.GitHub" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الشيفرة المصدرية"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アーティスト"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quellcode"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "아티스트"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source Code"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nghệ Sĩ"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código fuente"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "艺人"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code source"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "藝人"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सोर्स कोड"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Interpret"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kode Sumber"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artista"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codice sorgente"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artiste"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソースコード"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artista"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "소스 코드"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artista"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kod Sumber"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ศิลปิน"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Broncode"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artis"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kod źródłowy"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sanatçı"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Código-fonte"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wykonawca"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ซอร์สโค้ด"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الفنان"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak Kodu"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artiest"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mã Nguồn"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Artis"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "源代码"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कलाकार"
-          }
-        }
-      }
-    },
-    "Tag.Composer": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Composer"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "作曲家"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "작곡가"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhạc Sĩ"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "作曲家"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "作曲家"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Komponist"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compositor"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compositeur"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compositore"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Compositor"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้แต่งเพลง"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Komposer"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Besteci"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kompozytor"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الملحن"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Componist"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Komposer"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "संगीतकार"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原始碼"
           }
         }
       }
     },
-    "Tag.DiscNumber": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disc Number"
+    "Shared.Done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ディスク番号"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "디스크 번호"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Số Đĩa"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "光盘编号"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminé"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "光碟編號"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "पूर्ण"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CD-Nummer"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selesai"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Número de disco"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fatto"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numéro de disque"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numero disco"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Número do disco"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selesai"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หมายเลขแผ่น"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gereed"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nomor Disk"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gotowe"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disk Numarası"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Concluído"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numer płyty"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เสร็จ"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "رقم القرص"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitti"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schijfnummer"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xong"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nombor Cakera"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डिस्क नंबर"
-          }
-        }
-      }
-    },
-    "Tag.Genre": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Genre"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ジャンル"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "장르"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thể Loại"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "流派"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "流派"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Genre"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Género"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Genre"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Genere"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gênero"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แนวเพลง"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Genre"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tür"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gatunek"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "النوع"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Genre"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Genre"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "शैली"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         }
       }
     },
-    "Tag.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Title"
+    "Shared.OK" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حسنًا"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タイトル"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제목"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tiêu Đề"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aceptar"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "标题"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "標題"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ठीक है"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Titel"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Título"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Titre"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Titolo"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Título"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ชื่อเพลง"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Judul"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Başlık"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tytuł"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ตกลง"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "العنوان"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamam"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Titel"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tajuk"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "शीर्षक"
-          }
-        }
-      }
-    },
-    "Tag.TrackNumber": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Track Number"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "トラック番号"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "트랙 번호"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Số Bài Hát"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "音轨编号"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "音軌編號"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Titelnummer"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Número de pista"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numéro de piste"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numero traccia"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Número da faixa"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "หมายเลขแทร็ก"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nomor Trek"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parça Numarası"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numer utworu"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "رقم المسار"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tracknummer"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nombor Trek"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ट्रैक नंबर"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
           }
         }
       }
     },
-    "Tag.Year": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Year"
+    "Shared.Save" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حفظ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "年"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sichern"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "년도"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Năm"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "年份"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "年份"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सहेजें"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jahr"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simpan"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Año"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salva"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Année"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anno"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ano"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Simpan"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปี"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bewaar"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tahun"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapisz"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Yıl"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvar"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rok"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "บันทึก"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "السنة"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaydet"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jaar"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lưu"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tahun"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वर्ष"
-          }
-        }
-      }
-    },
-    "TagEditor.RemoveAlbumArt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove Album Art"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アルバムカバーを削除"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "앨범 아트 제거"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xóa Ảnh Bìa Album"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "移除专辑封面"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "移除專輯封面"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Albumcover entfernen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminar portada del álbum"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer la pochette"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rimuovi copertina album"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remover capa do álbum"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลบปกอัลบั้ม"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hapus Sampul Album"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Albüm Kapağını Kaldır"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuń okładkę albumu"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إزالة غلاف الألبوم"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Albumhoes verwijderen"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alih Keluar Seni Album"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एल्बम आर्ट हटाएं"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存"
           }
         }
       }
     },
-    "TagEditor.SelectAlbumArt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Album Art"
+    "Tag.Album" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الألبوم"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アルバムカバーを選択"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "앨범 아트 선택"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chọn Ảnh Bìa Album"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Álbum"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择专辑封面"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選擇專輯封面"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एल्बम"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Albumcover auswählen"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar portada del álbum"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélectionner la pochette"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アルバム"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleziona copertina album"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앨범"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selecionar capa do álbum"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เลือกปกอัลบั้ม"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pilih Sampul Album"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Albüm Kapağı Seç"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Álbum"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wybierz okładkę albumu"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "อัลบั้ม"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اختيار غلاف الألبوم"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albüm"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Albumhoes selecteren"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pilih Seni Album"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "专辑"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एल्बम आर्ट चुनें"
-          }
-        }
-      }
-    },
-    "TagEditor.TagData": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tag Data"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タグ情報"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "태그 데이터"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dữ Liệu Thẻ"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "标签数据"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "標籤資料"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tag-Daten"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Datos de etiqueta"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Données du tag"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dati tag"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dados da tag"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อมูลแท็ก"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data Tag"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Etiket Verileri"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dane tagów"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بيانات الوسم"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taggegevens"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data Tag"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टैग डेटा"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專輯"
           }
         }
       }
     },
-    "TagEditor.Tip.Tokens.Text": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can use various tokens to make use of existing information (such as the MP3 file's filename) to edit your tags.\nScroll down to see the tokens you can use."
+    "Tag.AlbumArtist" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فنان الألبوم"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "変換トークンを利用すると、ファイル名など既存の情報を利用し、より速くタグの情報を記入することができます。\n下にスクロールすると、利用できるトークンがご覧になれます。"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album-Interpret"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다양한 토큰을 사용하여 기존 정보(MP3 파일의 파일 이름 등)를 활용하여 태그를 편집할 수 있습니다.\n아래로 스크롤하여 사용 가능한 토큰을 확인하세요."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Album Artist"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bạn có thể sử dụng các token khác nhau để tận dụng thông tin hiện có (chẳng hạn như tên tệp MP3) để chỉnh sửa thẻ của bạn.\nCuộn xuống để xem các token bạn có thể sử dụng."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artista del álbum"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "您可以使用各种令牌来利用现有信息（例如 MP3 文件的文件名）来编辑您的标签。\n向下滚动以查看您可以使用的令牌。"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artiste de l'album"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "您可以使用各種令牌來利用現有資訊（例如 MP3 檔案的檔案名稱）來編輯您的標籤。\n向下滾動以查看您可以使用的令牌。"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एल्बम कलाकार"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sie können verschiedene Token verwenden, um vorhandene Informationen (z. B. den Dateinamen der MP3-Datei) zum Bearbeiten Ihrer Tags zu nutzen.\nScrollen Sie nach unten, um die verfügbaren Token zu sehen."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artis Album"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Puedes usar varios tokens para aprovechar la información existente (como el nombre del archivo MP3) para editar tus etiquetas.\nDesplázate hacia abajo para ver los tokens disponibles."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artista dell'album"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vous pouvez utiliser différents jetons pour exploiter les informations existantes (comme le nom du fichier MP3) afin de modifier vos tags.\nFaites défiler vers le bas pour voir les jetons disponibles."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アルバムアーティスト"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Puoi usare vari token per sfruttare le informazioni esistenti (come il nome del file MP3) per modificare i tuoi tag.\nScorri verso il basso per vedere i token disponibili."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앨범 아티스트"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Você pode usar vários tokens para aproveitar informações existentes (como o nome do arquivo MP3) para editar suas tags.\nRole para baixo para ver os tokens disponíveis."
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artis Album"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คุณสามารถใช้โทเค็นต่าง ๆ เพื่อใช้ข้อมูลที่มีอยู่ (เช่น ชื่อไฟล์ MP3) ในการแก้ไขแท็กของคุณ\nเลื่อนลงเพื่อดูโทเค็นที่สามารถใช้ได้"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albumartiest"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anda dapat menggunakan berbagai token untuk memanfaatkan informasi yang ada (seperti nama file MP3) untuk mengedit tag Anda.\nGulir ke bawah untuk melihat token yang tersedia."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wykonawca albumu"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Etiketlerinizi düzenlemek için mevcut bilgilerden (MP3 dosyasının adı gibi) yararlanmak üzere çeşitli belirteçler kullanabilirsiniz.\nKullanabileceğiniz belirteçleri görmek için aşağı kaydırın."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artista do álbum"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Możesz używać różnych tokenów, aby wykorzystać istniejące informacje (takie jak nazwa pliku MP3) do edycji tagów.\nPrzewiń w dół, aby zobaczyć dostępne tokeny."
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ศิลปินอัลบั้ม"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يمكنك استخدام رموز مختلفة للاستفادة من المعلومات الموجودة (مثل اسم ملف MP3) لتعديل الوسوم.\nمرر لأسفل لرؤية الرموز المتاحة."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albüm Sanatçısı"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Je kunt verschillende tokens gebruiken om bestaande informatie (zoals de bestandsnaam van het MP3-bestand) te gebruiken bij het bewerken van je tags.\nScrol omlaag om de beschikbare tokens te zien."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nghệ Sĩ Album"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anda boleh menggunakan pelbagai token untuk memanfaatkan maklumat sedia ada (seperti nama fail MP3) untuk mengedit tag anda.\nTatal ke bawah untuk melihat token yang tersedia."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "专辑艺人"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आप अपने टैग संपादित करने के लिए मौजूदा जानकारी (जैसे MP3 फ़ाइल का नाम) का उपयोग करने हेतु विभिन्न टोकन का उपयोग कर सकते हैं।\nउपलब्ध टोकन देखने के लिए नीचे स्क्रॉल करें।"
-          }
-        }
-      }
-    },
-    "TagEditor.Tip.Tokens.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Using Tokens"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "より速く編集する方法"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "토큰 사용하기"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sử Dụng Token"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用令牌"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用令牌"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Token verwenden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usar tokens"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utiliser les jetons"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usare i token"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usando tokens"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การใช้โทเค็น"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Menggunakan Token"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Belirteçleri Kullanma"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Używanie tokenów"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استخدام الرموز"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tokens gebruiken"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Menggunakan Token"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टोकन का उपयोग"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專輯藝人"
           }
         }
       }
     },
-    "TagEditor.Tokens.Filename.Description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Represents the filename without its extension."
+    "Tag.Artist" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الفنان"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "拡張子なしのファイル名に変換します。"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interpret"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "확장자를 제외한 파일 이름을 나타냅니다."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artist"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đại diện cho tên tệp không có phần mở rộng."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artista"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "表示不带扩展名的文件名。"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artiste"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "表示不帶副檔名的檔案名稱。"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कलाकार"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Steht für den Dateinamen ohne Erweiterung."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artis"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Representa el nombre del archivo sin su extensión."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artista"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Représente le nom du fichier sans son extension."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アーティスト"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rappresenta il nome del file senza estensione."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아티스트"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Representa o nome do arquivo sem a extensão."
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artis"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แทนชื่อไฟล์โดยไม่มีนามสกุล"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artiest"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mewakili nama file tanpa ekstensinya."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wykonawca"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dosya adını uzantısı olmadan temsil eder."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artista"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reprezentuje nazwę pliku bez rozszerzenia."
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ศิลปิน"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يمثل اسم الملف بدون امتداده."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sanatçı"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vertegenwoordigt de bestandsnaam zonder extensie."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nghệ Sĩ"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mewakili nama fail tanpa sambungannya."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "艺人"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एक्सटेंशन के बिना फ़ाइल नाम का प्रतिनिधित्व करता है।"
-          }
-        }
-      }
-    },
-    "TagEditor.Tokens.SplitBack.Description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Represents the text in the filename after the '-' (dash) symbol. For example, \"Rick Astley - Never Gonna Give You Up.mp3\" will result in \"Never Gonna Give You Up\"."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイル名にある「-」の後ろのテキストに変換します。例えば、「さユり - 花の塔.mp3」の場合、「花の塔」になります。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "파일 이름에서 '-'(대시) 기호 뒤의 텍스트를 나타냅니다. 예를 들어, \"ミツキヨ - Unwelcome School.mp3\"는 \"Unwelcome School\"이 됩니다."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đại diện cho văn bản trong tên tệp sau ký hiệu '-' (gạch ngang). Ví dụ, \"Hoàng Thùy Linh - See Tình.mp3\" sẽ cho kết quả là \"See Tình\"."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "表示文件名中 '-'（破折号）符号之后的文本。例如，\"阿肆 - 熱愛105C的你.mp3\" 将得到 \"熱愛105C的你\"。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "表示檔案名稱中 '-'（破折號）符號之後的文字。例如，\"費玉清 - 一翦梅.mp3\" 將得到 \"一翦梅\"。"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Steht für den Text im Dateinamen nach dem Zeichen '-' (Bindestrich). Zum Beispiel ergibt \"Rick Astley - Never Gonna Give You Up.mp3\" den Wert \"Never Gonna Give You Up\"."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Representa el texto en el nombre del archivo después del símbolo '-' (guion). Por ejemplo, \"Rick Astley - Never Gonna Give You Up.mp3\" dará como resultado \"Never Gonna Give You Up\"."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Représente le texte dans le nom du fichier après le symbole '-' (tiret). Par exemple, \"Rick Astley - Never Gonna Give You Up.mp3\" donnera \"Never Gonna Give You Up\"."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rappresenta il testo nel nome del file dopo il simbolo '-' (trattino). Ad esempio, \"Rick Astley - Never Gonna Give You Up.mp3\" darà come risultato \"Never Gonna Give You Up\"."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Representa o texto no nome do arquivo após o símbolo '-' (traço). Por exemplo, \"Rick Astley - Never Gonna Give You Up.mp3\" resultará em \"Never Gonna Give You Up\"."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แทนข้อความในชื่อไฟล์หลังเครื่องหมาย '-' (ขีดกลาง) เช่น \"Rick Astley - Never Gonna Give You Up.mp3\" จะได้ผลลัพธ์เป็น \"Never Gonna Give You Up\""
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mewakili teks dalam nama file setelah simbol '-' (tanda hubung). Misalnya, \"Rick Astley - Never Gonna Give You Up.mp3\" akan menghasilkan \"Never Gonna Give You Up\"."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dosya adındaki '-' (tire) sembolünden sonraki metni temsil eder. Örneğin, \"Rick Astley - Never Gonna Give You Up.mp3\" dosyası \"Never Gonna Give You Up\" sonucunu verir."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reprezentuje tekst w nazwie pliku po symbolu '-' (myślnik). Na przykład \"Rick Astley - Never Gonna Give You Up.mp3\" da wynik \"Never Gonna Give You Up\"."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يمثل النص في اسم الملف بعد رمز '-' (شرطة). على سبيل المثال، \"Rick Astley - Never Gonna Give You Up.mp3\" سينتج \"Never Gonna Give You Up\"."
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vertegenwoordigt de tekst in de bestandsnaam na het '-' (streepje) symbool. Bijvoorbeeld, \"Rick Astley - Never Gonna Give You Up.mp3\" resulteert in \"Never Gonna Give You Up\"."
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mewakili teks dalam nama fail selepas simbol '-' (sengkang). Contohnya, \"Rick Astley - Never Gonna Give You Up.mp3\" akan menghasilkan \"Never Gonna Give You Up\"."
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "फ़ाइल नाम में '-' (डैश) चिह्न के बाद के टेक्स्ट का प्रतिनिधित्व करता है। उदाहरण के लिए, \"Rick Astley - Never Gonna Give You Up.mp3\" का परिणाम \"Never Gonna Give You Up\" होगा।"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "藝人"
           }
         }
       }
     },
-    "TagEditor.Tokens.SplitFront.Description": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Represents the text in the filename before the '-' (dash) symbol. For example, \"Rick Astley - Never Gonna Give You Up.mp3\" will result in \"Rick Astley\"."
+    "Tag.Composer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الملحن"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイル名にある「-」の前のテキストに変換します。例えば、「さユり - 花の塔.mp3」の場合、「さユり」になります。"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komponist"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "파일 이름에서 '-'(대시) 기호 앞의 텍스트를 나타냅니다. 예를 들어, \"ミツキヨ - Unwelcome School.mp3\"는 \"ミツキヨ\"가 됩니다."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Composer"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đại diện cho văn bản trong tên tệp trước ký hiệu '-' (gạch ngang). Ví dụ, \"Hoàng Thùy Linh - See Tình.mp3\" sẽ cho kết quả là \"Hoàng Thùy Linh\"."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compositor"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "表示文件名中 '-'（破折号）符号之前的文本。例如，\"阿肆 - 熱愛105C的你.mp3\" 将得到 \"阿肆\"。"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compositeur"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "表示檔案名稱中 '-'（破折號）符號之前的文字。例如，\"費玉清 - 一翦梅.mp3\" 將得到 \"費玉清\"。"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "संगीतकार"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Steht für den Text im Dateinamen vor dem Zeichen '-' (Bindestrich). Zum Beispiel ergibt \"Rick Astley - Never Gonna Give You Up.mp3\" den Wert \"Rick Astley\"."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komposer"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Representa el texto en el nombre del archivo antes del símbolo '-' (guion). Por ejemplo, \"Rick Astley - Never Gonna Give You Up.mp3\" dará como resultado \"Rick Astley\"."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compositore"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Représente le texte dans le nom du fichier avant le symbole '-' (tiret). Par exemple, \"Rick Astley - Never Gonna Give You Up.mp3\" donnera \"Rick Astley\"."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作曲家"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rappresenta il testo nel nome del file prima del simbolo '-' (trattino). Ad esempio, \"Rick Astley - Never Gonna Give You Up.mp3\" darà come risultato \"Rick Astley\"."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작곡가"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Representa o texto no nome do arquivo antes do símbolo '-' (traço). Por exemplo, \"Rick Astley - Never Gonna Give You Up.mp3\" resultará em \"Rick Astley\"."
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komposer"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แทนข้อความในชื่อไฟล์ก่อนเครื่องหมาย '-' (ขีดกลาง) เช่น \"Rick Astley - Never Gonna Give You Up.mp3\" จะได้ผลลัพธ์เป็น \"Rick Astley\""
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Componist"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mewakili teks dalam nama file sebelum simbol '-' (tanda hubung). Misalnya, \"Rick Astley - Never Gonna Give You Up.mp3\" akan menghasilkan \"Rick Astley\"."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kompozytor"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dosya adındaki '-' (tire) sembolünden önceki metni temsil eder. Örneğin, \"Rick Astley - Never Gonna Give You Up.mp3\" dosyası \"Rick Astley\" sonucunu verir."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compositor"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reprezentuje tekst w nazwie pliku przed symbolem '-' (myślnik). Na przykład \"Rick Astley - Never Gonna Give You Up.mp3\" da wynik \"Rick Astley\"."
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ผู้แต่งเพลง"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يمثل النص في اسم الملف قبل رمز '-' (شرطة). على سبيل المثال، \"Rick Astley - Never Gonna Give You Up.mp3\" سينتج \"Rick Astley\"."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Besteci"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vertegenwoordigt de tekst in de bestandsnaam vóór het '-' (streepje) symbool. Bijvoorbeeld, \"Rick Astley - Never Gonna Give You Up.mp3\" resulteert in \"Rick Astley\"."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhạc Sĩ"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mewakili teks dalam nama fail sebelum simbol '-' (sengkang). Contohnya, \"Rick Astley - Never Gonna Give You Up.mp3\" akan menghasilkan \"Rick Astley\"."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作曲家"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "फ़ाइल नाम में '-' (डैश) चिह्न से पहले के टेक्स्ट का प्रतिनिधित्व करता है। उदाहरण के लिए, \"Rick Astley - Never Gonna Give You Up.mp3\" का परिणाम \"Rick Astley\" होगा।"
-          }
-        }
-      }
-    },
-    "TagEditor.Tokens.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Available Tokens"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "変換トークン"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사용 가능한 토큰"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Các Token Khả Dụng"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "可用令牌"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "可用令牌"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verfügbare Token"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tokens disponibles"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jetons disponibles"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Token disponibili"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tokens disponíveis"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "โทเค็นที่ใช้ได้"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Token yang Tersedia"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kullanılabilir Belirteçler"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dostępne tokeny"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الرموز المتاحة"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beschikbare tokens"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Token yang Tersedia"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "उपलब्ध टोकन"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作曲家"
           }
         }
       }
     },
-    "ViewTitle.More": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More"
+    "Tag.DiscNumber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رقم القرص"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "その他"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CD-Nummer"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "더 보기"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disc Number"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thêm"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Número de disco"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更多"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numéro de disque"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更多"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "डिस्क नंबर"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mehr"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nomor Disk"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Más"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero disco"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Plus"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ディスク番号"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Altro"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디스크 번호"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mais"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombor Cakera"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เพิ่มเติม"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schijfnummer"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lainnya"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numer płyty"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diğer"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Número do disco"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Więcej"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "หมายเลขแผ่น"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "المزيد"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disk Numarası"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Meer"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Số Đĩa"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lagi"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "光盘编号"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अधिक"
-          }
-        }
-      }
-    },
-    "Alert.NoMP3Files.Title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No MP3 Files Found"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MP3ファイルが見つかりません"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MP3 파일을 찾을 수 없음"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Không tìm thấy tệp MP3"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未找到MP3文件"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "找不到MP3檔案"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine MP3-Dateien gefunden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No se encontraron archivos MP3"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aucun fichier MP3 trouvé"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nessun file MP3 trovato"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nenhum arquivo MP3 encontrado"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ไม่พบไฟล์ MP3"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tidak Ada File MP3 Ditemukan"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MP3 Dosyası Bulunamadı"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nie znaleziono plików MP3"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لم يتم العثور على ملفات MP3"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geen MP3-bestanden gevonden"
-          }
-        },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tiada Fail MP3 Ditemui"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कोई MP3 फ़ाइल नहीं मिली"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "光碟編號"
           }
         }
       }
     },
-    "Alert.NoMP3Files.Message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The selection does not contain any MP3 files."
+    "Tag.Genre" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "النوع"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択された項目にMP3ファイルが含まれていません。"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genre"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "선택한 항목에 MP3 파일이 없습니다."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genre"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lựa chọn không chứa tệp MP3 nào."
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Género"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所选内容不包含任何MP3文件。"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genre"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所選內容不包含任何MP3檔案。"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "शैली"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Auswahl enthält keine MP3-Dateien."
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genre"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La selección no contiene archivos MP3."
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genere"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La sélection ne contient aucun fichier MP3."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ジャンル"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La selezione non contiene file MP3."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "장르"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A seleção não contém nenhum arquivo MP3."
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genre"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รายการที่เลือกไม่มีไฟล์ MP3"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genre"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pilihan tidak berisi file MP3."
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gatunek"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seçim herhangi bir MP3 dosyası içermiyor."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gênero"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zaznaczenie nie zawiera plików MP3."
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "แนวเพลง"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "التحديد لا يحتوي على أي ملفات MP3."
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tür"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "De selectie bevat geen MP3-bestanden."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thể Loại"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pilihan tidak mengandungi sebarang fail MP3."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流派"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "चयन में कोई MP3 फ़ाइल नहीं है।"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流派"
           }
         }
       }
     },
-    "Shared.OK": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+    "Tag.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "العنوان"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titel"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "확인"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Title"
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Título"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "好"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titre"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "好"
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "शीर्षक"
           }
         },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Judul"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aceptar"
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titolo"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトル"
           }
         },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제목"
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tajuk"
           }
         },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตกลง"
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titel"
           }
         },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tytuł"
           }
         },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamam"
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Título"
           }
         },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ชื่อเพลง"
           }
         },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حسنًا"
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Başlık"
           }
         },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiêu Đề"
           }
         },
-        "ms": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标题"
           }
         },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ठीक है"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題"
+          }
+        }
+      }
+    },
+    "Tag.TrackNumber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رقم المسار"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titelnummer"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Track Number"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Número de pista"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numéro de piste"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ट्रैक नंबर"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nomor Trek"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero traccia"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トラック番号"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "트랙 번호"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombor Trek"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tracknummer"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numer utworu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Número da faixa"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "หมายเลขแทร็ก"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parça Numarası"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Số Bài Hát"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音轨编号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音軌編號"
+          }
+        }
+      }
+    },
+    "Tag.Year" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "السنة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jahr"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Year"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Año"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Année"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "वर्ष"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tahun"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anno"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "년도"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tahun"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jaar"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rok"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ปี"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yıl"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Năm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年份"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年份"
+          }
+        }
+      }
+    },
+    "TagEditor.RemoveAlbumArt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إزالة غلاف الألبوم"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albumcover entfernen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove Album Art"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar portada del álbum"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer la pochette"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एल्बम आर्ट हटाएं"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus Sampul Album"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi copertina album"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アルバムカバーを削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앨범 아트 제거"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alih Keluar Seni Album"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albumhoes verwijderen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuń okładkę albumu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remover capa do álbum"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ลบปกอัลบั้ม"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albüm Kapağını Kaldır"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa Ảnh Bìa Album"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除专辑封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除專輯封面"
+          }
+        }
+      }
+    },
+    "TagEditor.SelectAlbumArt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختيار غلاف الألبوم"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albumcover auswählen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Album Art"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar portada del álbum"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner la pochette"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एल्बम आर्ट चुनें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih Sampul Album"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona copertina album"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アルバムカバーを選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앨범 아트 선택"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih Seni Album"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albumhoes selecteren"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz okładkę albumu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecionar capa do álbum"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เลือกปกอัลบั้ม"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Albüm Kapağı Seç"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn Ảnh Bìa Album"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择专辑封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇專輯封面"
+          }
+        }
+      }
+    },
+    "TagEditor.TagData" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بيانات الوسم"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tag-Daten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tag Data"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datos de etiqueta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Données du tag"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "टैग डेटा"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Tag"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dati tag"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ情報"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "태그 데이터"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Tag"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taggegevens"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dane tagów"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dados da tag"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ข้อมูลแท็ก"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiket Verileri"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dữ Liệu Thẻ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标签数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標籤資料"
+          }
+        }
+      }
+    },
+    "TagEditor.Tip.Tokens.Text" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكنك استخدام رموز مختلفة للاستفادة من المعلومات الموجودة (مثل اسم ملف MP3) لتعديل الوسوم.\nمرر لأسفل لرؤية الرموز المتاحة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie können verschiedene Token verwenden, um vorhandene Informationen (z. B. den Dateinamen der MP3-Datei) zum Bearbeiten Ihrer Tags zu nutzen.\nScrollen Sie nach unten, um die verfügbaren Token zu sehen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can use various tokens to make use of existing information (such as the MP3 file's filename) to edit your tags.\nScroll down to see the tokens you can use."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puedes usar varios tokens para aprovechar la información existente (como el nombre del archivo MP3) para editar tus etiquetas.\nDesplázate hacia abajo para ver los tokens disponibles."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous pouvez utiliser différents jetons pour exploiter les informations existantes (comme le nom du fichier MP3) afin de modifier vos tags.\nFaites défiler vers le bas pour voir les jetons disponibles."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "आप अपने टैग संपादित करने के लिए मौजूदा जानकारी (जैसे MP3 फ़ाइल का नाम) का उपयोग करने हेतु विभिन्न टोकन का उपयोग कर सकते हैं।\nउपलब्ध टोकन देखने के लिए नीचे स्क्रॉल करें।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda dapat menggunakan berbagai token untuk memanfaatkan informasi yang ada (seperti nama file MP3) untuk mengedit tag Anda.\nGulir ke bawah untuk melihat token yang tersedia."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puoi usare vari token per sfruttare le informazioni esistenti (come il nome del file MP3) per modificare i tuoi tag.\nScorri verso il basso per vedere i token disponibili."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変換トークンを利用すると、ファイル名など既存の情報を利用し、より速くタグの情報を記入することができます。\n下にスクロールすると、利用できるトークンがご覧になれます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다양한 토큰을 사용하여 기존 정보(MP3 파일의 파일 이름 등)를 활용하여 태그를 편집할 수 있습니다.\n아래로 스크롤하여 사용 가능한 토큰을 확인하세요."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda boleh menggunakan pelbagai token untuk memanfaatkan maklumat sedia ada (seperti nama fail MP3) untuk mengedit tag anda.\nTatal ke bawah untuk melihat token yang tersedia."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je kunt verschillende tokens gebruiken om bestaande informatie (zoals de bestandsnaam van het MP3-bestand) te gebruiken bij het bewerken van je tags.\nScrol omlaag om de beschikbare tokens te zien."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Możesz używać różnych tokenów, aby wykorzystać istniejące informacje (takie jak nazwa pliku MP3) do edycji tagów.\nPrzewiń w dół, aby zobaczyć dostępne tokeny."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Você pode usar vários tokens para aproveitar informações existentes (como o nome do arquivo MP3) para editar suas tags.\nRole para baixo para ver os tokens disponíveis."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "คุณสามารถใช้โทเค็นต่าง ๆ เพื่อใช้ข้อมูลที่มีอยู่ (เช่น ชื่อไฟล์ MP3) ในการแก้ไขแท็กของคุณ\nเลื่อนลงเพื่อดูโทเค็นที่สามารถใช้ได้"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiketlerinizi düzenlemek için mevcut bilgilerden (MP3 dosyasının adı gibi) yararlanmak üzere çeşitli belirteçler kullanabilirsiniz.\nKullanabileceğiniz belirteçleri görmek için aşağı kaydırın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn có thể sử dụng các token khác nhau để tận dụng thông tin hiện có (chẳng hạn như tên tệp MP3) để chỉnh sửa thẻ của bạn.\nCuộn xuống để xem các token bạn có thể sử dụng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您可以使用各种令牌来利用现有信息（例如 MP3 文件的文件名）来编辑您的标签。\n向下滚动以查看您可以使用的令牌。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您可以使用各種令牌來利用現有資訊（例如 MP3 檔案的檔案名稱）來編輯您的標籤。\n向下滾動以查看您可以使用的令牌。"
+          }
+        }
+      }
+    },
+    "TagEditor.Tip.Tokens.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استخدام الرموز"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token verwenden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Using Tokens"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar tokens"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliser les jetons"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "टोकन का उपयोग"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menggunakan Token"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usare i token"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "より速く編集する方法"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "토큰 사용하기"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menggunakan Token"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tokens gebruiken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Używanie tokenów"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usando tokens"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "การใช้โทเค็น"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Belirteçleri Kullanma"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sử Dụng Token"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用令牌"
+          }
+        }
+      }
+    },
+    "TagEditor.Tokens.Filename.Description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمثل اسم الملف بدون امتداده."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steht für den Dateinamen ohne Erweiterung."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Represents the filename without its extension."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Representa el nombre del archivo sin su extensión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Représente le nom du fichier sans son extension."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "एक्सटेंशन के बिना फ़ाइल नाम का प्रतिनिधित्व करता है।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mewakili nama file tanpa ekstensinya."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappresenta il nome del file senza estensione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拡張子なしのファイル名に変換します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확장자를 제외한 파일 이름을 나타냅니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mewakili nama fail tanpa sambungannya."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vertegenwoordigt de bestandsnaam zonder extensie."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprezentuje nazwę pliku bez rozszerzenia."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Representa o nome do arquivo sem a extensão."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "แทนชื่อไฟล์โดยไม่มีนามสกุล"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dosya adını uzantısı olmadan temsil eder."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đại diện cho tên tệp không có phần mở rộng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示不带扩展名的文件名。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示不帶副檔名的檔案名稱。"
+          }
+        }
+      }
+    },
+    "TagEditor.Tokens.SplitBack.Description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمثل النص في اسم الملف بعد رمز '-' (شرطة). على سبيل المثال، \"Rick Astley - Never Gonna Give You Up.mp3\" سينتج \"Never Gonna Give You Up\"."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steht für den Text im Dateinamen nach dem Zeichen '-' (Bindestrich). Zum Beispiel ergibt \"Rick Astley - Never Gonna Give You Up.mp3\" den Wert \"Never Gonna Give You Up\"."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Represents the text in the filename after the '-' (dash) symbol. For example, \"Rick Astley - Never Gonna Give You Up.mp3\" will result in \"Never Gonna Give You Up\"."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Representa el texto en el nombre del archivo después del símbolo '-' (guion). Por ejemplo, \"Rick Astley - Never Gonna Give You Up.mp3\" dará como resultado \"Never Gonna Give You Up\"."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Représente le texte dans le nom du fichier après le symbole '-' (tiret). Par exemple, \"Rick Astley - Never Gonna Give You Up.mp3\" donnera \"Never Gonna Give You Up\"."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "फ़ाइल नाम में '-' (डैश) चिह्न के बाद के टेक्स्ट का प्रतिनिधित्व करता है। उदाहरण के लिए, \"Rick Astley - Never Gonna Give You Up.mp3\" का परिणाम \"Never Gonna Give You Up\" होगा।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mewakili teks dalam nama file setelah simbol '-' (tanda hubung). Misalnya, \"Rick Astley - Never Gonna Give You Up.mp3\" akan menghasilkan \"Never Gonna Give You Up\"."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappresenta il testo nel nome del file dopo il simbolo '-' (trattino). Ad esempio, \"Rick Astley - Never Gonna Give You Up.mp3\" darà come risultato \"Never Gonna Give You Up\"."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイル名にある「-」の後ろのテキストに変換します。例えば、「さユり - 花の塔.mp3」の場合、「花の塔」になります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파일 이름에서 '-'(대시) 기호 뒤의 텍스트를 나타냅니다. 예를 들어, \"ミツキヨ - Unwelcome School.mp3\"는 \"Unwelcome School\"이 됩니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mewakili teks dalam nama fail selepas simbol '-' (sengkang). Contohnya, \"Rick Astley - Never Gonna Give You Up.mp3\" akan menghasilkan \"Never Gonna Give You Up\"."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vertegenwoordigt de tekst in de bestandsnaam na het '-' (streepje) symbool. Bijvoorbeeld, \"Rick Astley - Never Gonna Give You Up.mp3\" resulteert in \"Never Gonna Give You Up\"."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprezentuje tekst w nazwie pliku po symbolu '-' (myślnik). Na przykład \"Rick Astley - Never Gonna Give You Up.mp3\" da wynik \"Never Gonna Give You Up\"."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Representa o texto no nome do arquivo após o símbolo '-' (traço). Por exemplo, \"Rick Astley - Never Gonna Give You Up.mp3\" resultará em \"Never Gonna Give You Up\"."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "แทนข้อความในชื่อไฟล์หลังเครื่องหมาย '-' (ขีดกลาง) เช่น \"Rick Astley - Never Gonna Give You Up.mp3\" จะได้ผลลัพธ์เป็น \"Never Gonna Give You Up\""
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dosya adındaki '-' (tire) sembolünden sonraki metni temsil eder. Örneğin, \"Rick Astley - Never Gonna Give You Up.mp3\" dosyası \"Never Gonna Give You Up\" sonucunu verir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đại diện cho văn bản trong tên tệp sau ký hiệu '-' (gạch ngang). Ví dụ, \"Hoàng Thùy Linh - See Tình.mp3\" sẽ cho kết quả là \"See Tình\"."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示文件名中 '-'（破折号）符号之后的文本。例如，\"阿肆 - 熱愛105C的你.mp3\" 将得到 \"熱愛105C的你\"。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示檔案名稱中 '-'（破折號）符號之後的文字。例如，\"費玉清 - 一翦梅.mp3\" 將得到 \"一翦梅\"。"
+          }
+        }
+      }
+    },
+    "TagEditor.Tokens.SplitFront.Description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمثل النص في اسم الملف قبل رمز '-' (شرطة). على سبيل المثال، \"Rick Astley - Never Gonna Give You Up.mp3\" سينتج \"Rick Astley\"."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steht für den Text im Dateinamen vor dem Zeichen '-' (Bindestrich). Zum Beispiel ergibt \"Rick Astley - Never Gonna Give You Up.mp3\" den Wert \"Rick Astley\"."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Represents the text in the filename before the '-' (dash) symbol. For example, \"Rick Astley - Never Gonna Give You Up.mp3\" will result in \"Rick Astley\"."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Representa el texto en el nombre del archivo antes del símbolo '-' (guion). Por ejemplo, \"Rick Astley - Never Gonna Give You Up.mp3\" dará como resultado \"Rick Astley\"."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Représente le texte dans le nom du fichier avant le symbole '-' (tiret). Par exemple, \"Rick Astley - Never Gonna Give You Up.mp3\" donnera \"Rick Astley\"."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "फ़ाइल नाम में '-' (डैश) चिह्न से पहले के टेक्स्ट का प्रतिनिधित्व करता है। उदाहरण के लिए, \"Rick Astley - Never Gonna Give You Up.mp3\" का परिणाम \"Rick Astley\" होगा।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mewakili teks dalam nama file sebelum simbol '-' (tanda hubung). Misalnya, \"Rick Astley - Never Gonna Give You Up.mp3\" akan menghasilkan \"Rick Astley\"."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rappresenta il testo nel nome del file prima del simbolo '-' (trattino). Ad esempio, \"Rick Astley - Never Gonna Give You Up.mp3\" darà come risultato \"Rick Astley\"."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイル名にある「-」の前のテキストに変換します。例えば、「さユり - 花の塔.mp3」の場合、「さユり」になります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파일 이름에서 '-'(대시) 기호 앞의 텍스트를 나타냅니다. 예를 들어, \"ミツキヨ - Unwelcome School.mp3\"는 \"ミツキヨ\"가 됩니다."
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mewakili teks dalam nama fail sebelum simbol '-' (sengkang). Contohnya, \"Rick Astley - Never Gonna Give You Up.mp3\" akan menghasilkan \"Rick Astley\"."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vertegenwoordigt de tekst in de bestandsnaam vóór het '-' (streepje) symbool. Bijvoorbeeld, \"Rick Astley - Never Gonna Give You Up.mp3\" resulteert in \"Rick Astley\"."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprezentuje tekst w nazwie pliku przed symbolem '-' (myślnik). Na przykład \"Rick Astley - Never Gonna Give You Up.mp3\" da wynik \"Rick Astley\"."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Representa o texto no nome do arquivo antes do símbolo '-' (traço). Por exemplo, \"Rick Astley - Never Gonna Give You Up.mp3\" resultará em \"Rick Astley\"."
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "แทนข้อความในชื่อไฟล์ก่อนเครื่องหมาย '-' (ขีดกลาง) เช่น \"Rick Astley - Never Gonna Give You Up.mp3\" จะได้ผลลัพธ์เป็น \"Rick Astley\""
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dosya adındaki '-' (tire) sembolünden önceki metni temsil eder. Örneğin, \"Rick Astley - Never Gonna Give You Up.mp3\" dosyası \"Rick Astley\" sonucunu verir."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đại diện cho văn bản trong tên tệp trước ký hiệu '-' (gạch ngang). Ví dụ, \"Hoàng Thùy Linh - See Tình.mp3\" sẽ cho kết quả là \"Hoàng Thùy Linh\"."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示文件名中 '-'（破折号）符号之前的文本。例如，\"阿肆 - 熱愛105C的你.mp3\" 将得到 \"阿肆\"。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示檔案名稱中 '-'（破折號）符號之前的文字。例如，\"費玉清 - 一翦梅.mp3\" 將得到 \"費玉清\"。"
+          }
+        }
+      }
+    },
+    "TagEditor.Tokens.Title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرموز المتاحة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verfügbare Token"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Available Tokens"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tokens disponibles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetons disponibles"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "उपलब्ध टोकन"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token yang Tersedia"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token disponibili"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変換トークン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 가능한 토큰"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token yang Tersedia"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beschikbare tokens"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dostępne tokeny"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tokens disponíveis"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "โทเค็นที่ใช้ได้"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kullanılabilir Belirteçler"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Các Token Khả Dụng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用令牌"
+          }
+        }
+      }
+    },
+    "ViewTitle.More" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المزيد"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehr"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अधिक"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lainnya"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "더 보기"
+          }
+        },
+        "ms" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lagi"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meer"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Więcej"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mais"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "เพิ่มเติม"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diğer"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thêm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更多"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更多"
           }
         }
       }
     }
   },
-  "version": "1.0"
+  "version" : "1.0"
 }

--- a/Tunetag/Structs/FSFile.swift
+++ b/Tunetag/Structs/FSFile.swift
@@ -24,11 +24,7 @@ struct FSFile: Hashable, Codable, Identifiable, Transferable {
     }
 
     static var transferRepresentation: some TransferRepresentation {
-        CodableRepresentation(for: FSFile.self, contentType: .file)
+        CodableRepresentation(for: FSFile.self, contentType: .audio)
         ProxyRepresentation(exporting: \.name)
     }
-}
-
-extension UTType {
-    static var file: UTType { UTType(exportedAs: "com.tsubuzaki.Tunetag.MP3File") }
 }

--- a/Tunetag/Structs/Tag.swift
+++ b/Tunetag/Structs/Tag.swift
@@ -28,9 +28,7 @@ struct Tag {
         artist = tagCombined.artist
         album = tagCombined.album
         albumArtist = tagCombined.albumArtist
-        if let year = tagCombined.year {
-            self.year = String(year)
-        }
+        year = tagCombined.year
         if let track = tagCombined.track {
             self.track = String(track)
         }

--- a/Tunetag/Structs/TagTyped.swift
+++ b/Tunetag/Structs/TagTyped.swift
@@ -5,116 +5,65 @@
 //  Created by シン・ジャスティン on 2023/09/09.
 //
 
-import AVFoundation
 import Foundation
-import ID3TagEditor
+import SFBAudioEngine
 
 struct TagTyped {
 
     var albumArt: Data?
-    var title, artist, album, albumArtist, genre, composer: String?
-    var year, track, discNumber: Int?
+    var title, artist, album, albumArtist, genre, composer, year: String?
+    var track, discNumber: Int?
 
-    init(_ file: FSFile, reader tagContentReader: ID3TagContentReader) async {
-        title = tagContentReader.title()
-        artist = tagContentReader.artist()
-        album = tagContentReader.album()
-        albumArtist = tagContentReader.albumArtist()
-        if let yearFromTag = tagContentReader.recordingYear() {
-            year = yearFromTag
-        }
-        if let trackFromTag = tagContentReader.trackPosition()?.position {
-            track = trackFromTag
-        }
-        genre = tagContentReader.genre()?.description
-        composer = tagContentReader.composer()
-        if let discNumberFromTag = tagContentReader.discPosition()?.position {
-            discNumber = discNumberFromTag
-        }
-        if let albumArtFromTag = tagContentReader.attachedPictures()
-                .first(where: { $0.type == .frontCover }) {
-            albumArt = albumArtFromTag.picture
-        } else if let albumArtFromTag = tagContentReader.attachedPictures().first {
-            albumArt = albumArtFromTag.picture
-        } else {
-            albumArt = await albumArtUsingAVPlayer(file: file)
-        }
+    init(_ file: FSFile, metadata: AudioMetadata) {
+        title = metadata.title
+        artist = metadata.artist
+        album = metadata.albumTitle
+        albumArtist = metadata.albumArtist
+        year = metadata.releaseDate
+        track = metadata.trackNumber
+        discNumber = metadata.discNumber
+        genre = metadata.genre
+        composer = metadata.composer
+        albumArt = TagTyped.albumArtData(from: metadata)
     }
 
-    // swiftlint:disable cyclomatic_complexity function_body_length
-    mutating func merge(with file: FSFile, reader tagContentReader: ID3TagContentReader) async {
-        if title != tagContentReader.title() {
+    mutating func merge(with file: FSFile, metadata: AudioMetadata) {
+        if title != metadata.title {
             title = nil
         }
-        if artist != tagContentReader.artist() {
+        if artist != metadata.artist {
             artist = nil
         }
-        if album != tagContentReader.album() {
+        if album != metadata.albumTitle {
             album = nil
         }
-        if albumArtist != tagContentReader.albumArtist() {
+        if albumArtist != metadata.albumArtist {
             albumArtist = nil
         }
-        if let yearFromTag = tagContentReader.recordingYear(), year != yearFromTag {
-            year = nil
-        } else if tagContentReader.recordingYear() == nil && year != nil {
+        if year != metadata.releaseDate {
             year = nil
         }
-        if let trackFromTag = tagContentReader.trackPosition()?.position, track != trackFromTag {
-            track = nil
-        } else if tagContentReader.trackPosition()?.position == nil && track != nil {
+        if track != metadata.trackNumber {
             track = nil
         }
-        if genre != tagContentReader.genre()?.description {
+        if discNumber != metadata.discNumber {
+            discNumber = nil
+        }
+        if genre != metadata.genre {
             genre = nil
         }
-        if composer != tagContentReader.composer() {
+        if composer != metadata.composer {
             composer = nil
         }
-        if let discNumberFromTag = tagContentReader.discPosition()?.position,
-           discNumber != discNumberFromTag {
-            discNumber = nil
-        } else if tagContentReader.discPosition()?.position == nil && discNumber != nil {
-            discNumber = nil
-        }
-        if let albumArtFromTag = tagContentReader.attachedPictures().first(where: { picture in
-            picture.type == .frontCover
-        }) {
-            if albumArt != albumArtFromTag.picture {
-                albumArt = nil
-            }
-        } else if let albumArtFromTag = tagContentReader.attachedPictures().first {
-            if albumArt != albumArtFromTag.picture {
-                albumArt = nil
-            }
-        } else if let albumArtFromTag = await albumArtUsingAVPlayer(file: file) {
-            if albumArt != albumArtFromTag {
-                albumArt = nil
-            }
-        } else {
-            if albumArt != nil {
-                albumArt = nil
-            }
+        if albumArt != TagTyped.albumArtData(from: metadata) {
+            albumArt = nil
         }
     }
-    // swiftlint:enable cyclomatic_complexity function_body_length
 
-    func albumArtUsingAVPlayer(file: FSFile) async -> Data? {
-        do {
-            let playerItem = AVPlayerItem(url: URL(filePath: file.path))
-            let metadataList = try await playerItem.asset.load(.metadata)
-            for item in metadataList {
-                switch item.commonKey {
-                case .commonKeyArtwork?:
-                    if let data = try await item.load(.dataValue) {
-                        return data
-                    }
-                default: break
-                }
-            }
-        } catch {
-            debugPrint(error.localizedDescription)
+    static func albumArtData(from metadata: AudioMetadata) -> Data? {
+        if let frontCover = metadata.attachedPictures(ofType: .frontCover).first {
+            return frontCover.imageData
         }
-        return nil
+        return metadata.attachedPictures.first?.imageData
     }
 }

--- a/Tunetag/Views/Components/LargeButtonLabel.swift
+++ b/Tunetag/Views/Components/LargeButtonLabel.swift
@@ -1,0 +1,28 @@
+//
+//  LargeButtonLabel.swift
+//  Tunetag
+//
+
+import SwiftUI
+
+struct LargeButtonLabel: View {
+
+    var iconName: String?
+    var text: String
+
+    init(iconName: String? = nil, text: String) {
+        self.iconName = iconName
+        self.text = text
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 4.0) {
+            if let iconName = iconName {
+                Image(systemName: iconName)
+            }
+            Text(NSLocalizedString(text, comment: ""))
+                .padding([.top, .bottom], 8.0)
+        }
+        .padding([.leading, .trailing], 10.0)
+    }
+}

--- a/Tunetag/Views/Components/ListSectionHeader.swift
+++ b/Tunetag/Views/Components/ListSectionHeader.swift
@@ -1,0 +1,26 @@
+//
+//  ListSectionHeader.swift
+//  Tunetag
+//
+
+import SwiftUI
+
+struct ListSectionHeader: View {
+
+    var text: String
+
+    init(text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(LocalizedStringKey(text))
+            .font(.body)
+            .fontWeight(.bold)
+            .foregroundColor(.primary)
+            .textCase(nil)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .allowsTightening(true)
+    }
+}

--- a/Tunetag/Views/More/MoreLicensesView.swift
+++ b/Tunetag/Views/More/MoreLicensesView.swift
@@ -38,11 +38,11 @@ private struct Dependency: Identifiable {
     }
 
     static let all: [Dependency] = [
-        Dependency(name: "ID3TagEditor", licenseText:
+        Dependency(name: "SFBAudioEngine", licenseText:
 """
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2018 Fabrizio Duroni
+Copyright (c) 2006-2026 Stephen F. Booth
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Tunetag/Views/More/MoreLicensesView.swift
+++ b/Tunetag/Views/More/MoreLicensesView.swift
@@ -6,62 +6,56 @@
 import SwiftUI
 
 struct MoreLicensesView: View {
+    private let dependencies: [Dependency] = Dependency.loadAll()
+    @State private var expanded: Set<String> = []
+
     var body: some View {
         List {
-            ForEach(Dependency.all) { dependency in
-                Section {
+            ForEach(dependencies) { dependency in
+                DisclosureGroup(
+                    isExpanded: Binding(
+                        get: { expanded.contains(dependency.id) },
+                        set: { isOn in
+                            if isOn {
+                                expanded.insert(dependency.id)
+                            } else {
+                                expanded.remove(dependency.id)
+                            }
+                        }
+                    )
+                ) {
                     Text(dependency.licenseText)
                         .font(.caption)
                         .monospaced()
-                        .listRowBackground(Color.clear)
-                } header: {
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } label: {
                     Text(dependency.name)
+                        .monospaced()
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }
-        .listStyle(.grouped)
+        .listStyle(.plain)
         .navigationTitle("More.Attributions")
         .navigationBarTitleDisplayMode(.inline)
     }
 }
 
-// swiftlint:disable type_body_length
-private struct Dependency: Identifiable {
-    let id: String
+private struct Dependency: Identifiable, Decodable {
+    var id: String { name }
     let name: String
     let licenseText: String
 
-    init(name: String, licenseText: String) {
-        self.id = name
-        self.name = name
-        self.licenseText = licenseText
+    static func loadAll() -> [Dependency] {
+        guard let url = Bundle.main.url(forResource: "Licenses", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let wrapper = try? PropertyListDecoder().decode(Wrapper.self, from: data) else {
+            return []
+        }
+        return wrapper.dependencies
     }
 
-    static let all: [Dependency] = [
-        Dependency(name: "SFBAudioEngine", licenseText:
-"""
-MIT License
-
-Copyright (c) 2006-2026 Stephen F. Booth
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-""")
-    ]
+    private struct Wrapper: Decodable {
+        let dependencies: [Dependency]
+    }
 }
-// swiftlint:enable type_body_length

--- a/Tunetag/Views/Tag Editor/TagDataSection.swift
+++ b/Tunetag/Views/Tag Editor/TagDataSection.swift
@@ -6,7 +6,6 @@
 //
 
 import Combine
-import Komponents
 import SwiftUI
 
 struct TagDataSection: View {

--- a/Tunetag/Views/Tag Editor/TagEditorView.swift
+++ b/Tunetag/Views/Tag Editor/TagEditorView.swift
@@ -5,7 +5,6 @@
 //  Created by シン・ジャスティン on 2023/09/08.
 //
 
-import Komponents
 import PhotosUI
 import SFBAudioEngine
 import SwiftUI
@@ -212,7 +211,12 @@ struct TagEditorView: View {
         debugPrint("Attempting to save tag data...")
         do {
             let url = URL(filePath: file.path)
-            let audioFile = audioFiles[file] ?? (try AudioFile(readingPropertiesAndMetadataFrom: url))
+            let audioFile: AudioFile
+            if let cached = audioFiles[file] {
+                audioFile = cached
+            } else {
+                audioFile = try AudioFile(readingPropertiesAndMetadataFrom: url)
+            }
             let metadata = audioFile.metadata
             applyEdits(to: metadata, for: file)
             try audioFile.writeMetadata()

--- a/Tunetag/Views/Tag Editor/TagEditorView.swift
+++ b/Tunetag/Views/Tag Editor/TagEditorView.swift
@@ -5,18 +5,16 @@
 //  Created by シン・ジャスティン on 2023/09/08.
 //
 
-import ID3TagEditor
 import Komponents
 import PhotosUI
+import SFBAudioEngine
 import SwiftUI
 import TipKit
 
-// swiftlint:disable type_body_length
 struct TagEditorView: View {
 
-    let id3TagEditor = ID3TagEditor()
     @State var files: [FSFile]
-    @State var tags: [FSFile: ID3Tag] = [:]
+    @State var audioFiles: [FSFile: AudioFile] = [:]
     @State var tagData = Tag()
     @State var selectedAlbumArt: PhotosPickerItem?
     @State var isAlbumArtRemoved: Bool = false
@@ -158,30 +156,25 @@ struct TagEditorView: View {
 
     func readAllTagData() async {
         debugPrint("Attempting to read tag data for \(files.count) files...")
-        // Check for common tag data betwen all files
         var tagCombined: TagTyped?
+        var loadedAudioFiles: [FSFile: AudioFile] = [:]
         for file in files {
             debugPrint("Attempting to read tag data for file \(file.name)...")
             do {
-                let tag = try id3TagEditor.read(from: file.path)
-                if let tag {
-                    tags.updateValue(tag, forKey: file)
-                    let tagContentReader = ID3TagContentReader(id3Tag: tag)
-                    if tagCombined == nil {
-                        tagCombined = await TagTyped(file, reader: tagContentReader)
-                    } else {
-                        await tagCombined!.merge(with: file, reader: tagContentReader)
-                    }
+                let url = URL(filePath: file.path)
+                let audioFile = try AudioFile(readingPropertiesAndMetadataFrom: url)
+                loadedAudioFiles[file] = audioFile
+                let metadata = audioFile.metadata
+                if tagCombined == nil {
+                    tagCombined = TagTyped(file, metadata: metadata)
                 } else {
-                    if let newTag = newTag(for: file) {
-                        tags.updateValue(newTag, forKey: file)
-                    }
+                    tagCombined!.merge(with: file, metadata: metadata)
                 }
             } catch {
                 debugPrint("Error occurred while reading tags: \n\(error.localizedDescription)")
             }
         }
-        // Load data into view
+        audioFiles = loadedAudioFiles
         if let tagCombined = tagCombined {
             tagData = Tag(from: tagCombined)
         }
@@ -213,202 +206,81 @@ struct TagEditorView: View {
             }
             return saveStates
         }
-        // TODO: Report status of save
     }
 
-    // swiftlint:disable cyclomatic_complexity
-    // swiftlint:disable function_body_length
-    func saveTagData(to file: FSFile, retriesWhenFailed willRetry: Bool = true) -> Bool {
+    func saveTagData(to file: FSFile) -> Bool {
         debugPrint("Attempting to save tag data...")
         do {
-            let tag = tags[file]
-            var tagBuilder = ID32v3TagBuilder()
-            // Build title frame
-            if let frame = id3Frame(tagData.title, returns: ID3FrameWithStringContent.self, referencing: file) {
-                tagBuilder = tagBuilder.title(frame: frame)
-            } else if let tag = tag, let value = ID3TagContentReader(id3Tag: tag).title() {
-                tagBuilder = tagBuilder.title(frame: id3Frame(value, referencing: file))
-            }
-            // Build artist frame
-            if let frame = id3Frame(tagData.artist, returns: ID3FrameWithStringContent.self, referencing: file) {
-                tagBuilder = tagBuilder.artist(frame: frame)
-            } else if let tag = tag, let value = ID3TagContentReader(id3Tag: tag).artist() {
-                tagBuilder = tagBuilder.artist(frame: id3Frame(value, referencing: file))
-            }
-            // Build album frame
-            if let frame = id3Frame(tagData.album, returns: ID3FrameWithStringContent.self, referencing: file) {
-                tagBuilder = tagBuilder.album(frame: frame)
-            } else if let tag = tag, let value = ID3TagContentReader(id3Tag: tag).album() {
-                tagBuilder = tagBuilder.album(frame: id3Frame(value, referencing: file))
-            }
-            // Build album artist frame
-            if let frame = id3Frame(tagData.albumArtist, returns: ID3FrameWithStringContent.self, referencing: file) {
-                tagBuilder = tagBuilder.albumArtist(frame: frame)
-            } else if let tag = tag, let value = ID3TagContentReader(id3Tag: tag).albumArtist() {
-                tagBuilder = tagBuilder.albumArtist(frame: id3Frame(value, referencing: file))
-            }
-            // Build year frame
-            if let frame = id3Frame(tagData.year, returns: ID3FrameWithIntegerContent.self) {
-                tagBuilder = tagBuilder.recordingYear(frame: frame)
-            } else if let tag = tag, let value = ID3TagContentReader(id3Tag: tag).recordingYear() {
-                tagBuilder = tagBuilder.recordingYear(frame: ID3FrameWithIntegerContent(value: value))
-            }
-            // Build track frame
-            if let frame = id3Frame(tagData.track, returns: ID3FramePartOfTotal.self), frame.part != -999999 {
-                tagBuilder = tagBuilder.trackPosition(frame: frame)
-            } else if tagData.track == nil, let tag = tag, let value = ID3TagContentReader(id3Tag: tag).trackPosition() {
-                tagBuilder = tagBuilder.trackPosition(frame: id3Frame(value.position, total: value.total))
-            }
-            // Build genre frame
-            if let frame = id3Frame(tagData.genre, returns: ID3FrameGenre.self) {
-                tagBuilder = tagBuilder.genre(frame: frame)
-            } else if let tag = tag, let value = ID3TagContentReader(id3Tag: tag).genre(),
-                      let description = value.description {
-                tagBuilder = tagBuilder.genre(frame: id3Frame(description, identifier: value.identifier))
-            }
-            // Build composer frame
-            if let frame = id3Frame(tagData.composer, returns: ID3FrameWithStringContent.self, referencing: file) {
-                tagBuilder = tagBuilder.composer(frame: frame)
-            } else if let tag = tag, let value = ID3TagContentReader(id3Tag: tag).composer() {
-                tagBuilder = tagBuilder.composer(frame: id3Frame(value, referencing: file))
-            }
-            // Build disc number frame
-            if let frame = id3Frame(tagData.discNumber, returns: ID3FramePartOfTotal.self), frame.part != -999999 {
-                tagBuilder = tagBuilder.discPosition(frame: frame)
-            } else if tagData.discNumber == nil, let tag = tag,
-                      let value = ID3TagContentReader(id3Tag: tag).discPosition() {
-                tagBuilder = tagBuilder.discPosition(frame: id3Frame(value.position, total: value.total))
-            }
-            // Build album art frame
-            if let frame = id3Frame(tagData.albumArt, type: .frontCover) {
-                tagBuilder = tagBuilder.attachedPicture(pictureType: .frontCover, frame: frame)
-            } else if !isAlbumArtRemoved, let tag = tag,
-                      let albumArt = ID3TagContentReader(id3Tag: tag).attachedPictures()
-                .first(where: { $0.type == .frontCover }),
-                      let frame = id3Frame(albumArt.picture, type: .frontCover) {
-                tagBuilder = tagBuilder
-                    .attachedPicture(pictureType: .frontCover, frame: frame)
-            }
-            try id3TagEditor.write(tag: tagBuilder.build(), to: file.path)
+            let url = URL(filePath: file.path)
+            let audioFile = audioFiles[file] ?? (try AudioFile(readingPropertiesAndMetadataFrom: url))
+            let metadata = audioFile.metadata
+            applyEdits(to: metadata, for: file)
+            try audioFile.writeMetadata()
             return true
         } catch {
             debugPrint("Error occurred while saving tag: \n\(error.localizedDescription)")
-            if willRetry {
-                initializeTag(for: file)
-                return saveTagData(to: file, retriesWhenFailed: false)
-            } else {
-                return false
-            }
-        }
-    }
-    // swiftlint:enable cyclomatic_complexity
-    // swiftlint:enable function_body_length
-
-    func newTag(for file: FSFile) -> ID3Tag? {
-        debugPrint("Attempting to create new tag...")
-        do {
-            let id3Tag = ID32v3TagBuilder()
-                .title(frame: ID3FrameWithStringContent(content: ""))
-                .build()
-            try ID3TagEditor().write(tag: id3Tag, to: file.path)
-            return id3Tag
-        } catch {
-            debugPrint("Error occurred while initializing tag: \n\(error.localizedDescription)")
-        }
-        return nil
-    }
-
-    func initializeTag(for file: FSFile) {
-        debugPrint("Attempting to initialize tag...")
-        do {
-            let id3Tag = ID32v3TagBuilder()
-                .title(frame: ID3FrameWithStringContent(content: ""))
-                .build()
-            try id3TagEditor.write(tag: id3Tag, to: file.path)
-        } catch {
-            debugPrint("Error occurred while initializing tag: \n\(error.localizedDescription)")
+            return false
         }
     }
 
-    func id3Frame<T>(_ value: String?,
-                     returns type: T.Type,
-                     referencing file: FSFile? = nil) -> T? {
-        switch type {
-        case is ID3FrameWithStringContent.Type:
-            if let value {
-                if let file = file {
-                    return ID3FrameWithStringContent(content: replaceTokens(value, file: file)) as? T
-                } else {
-                    return ID3FrameWithStringContent(content: value) as? T
-                }
-            }
-        case is ID3FrameWithIntegerContent.Type:
-            if let value {
-                if let int = Int(value) {
-                    return ID3FrameWithIntegerContent(value: int) as? T
-                } else {
-                    return ID3FrameWithIntegerContent(value: nil) as? T
-                }
-            }
-        case is ID3FramePartOfTotal.Type:
-            if let value {
-                if value != "", let int = Int(value) {
-                    return ID3FramePartOfTotal(part: int, total: nil) as? T
-                } else {
-                    return ID3FramePartOfTotal(part: -999999, total: nil) as? T
-                }
-            }
-        case is ID3FrameGenre.Type:
-            if let value {
-                return ID3FrameGenre(genre: nil, description: value) as? T
-            }
-        default: break
+    private func applyEdits(to metadata: AudioMetadata, for file: FSFile) {
+        if let title = tagData.title {
+            metadata.title = replaceTokens(title, file: file)
         }
-        return nil
+        if let artist = tagData.artist {
+            metadata.artist = replaceTokens(artist, file: file)
+        }
+        if let album = tagData.album {
+            metadata.albumTitle = replaceTokens(album, file: file)
+        }
+        if let albumArtist = tagData.albumArtist {
+            metadata.albumArtist = replaceTokens(albumArtist, file: file)
+        }
+        if let year = tagData.year {
+            metadata.releaseDate = year.isEmpty ? nil : year
+        }
+        if let track = tagData.track {
+            metadata.trackNumber = track.isEmpty ? nil : Int(track)
+        }
+        if let genre = tagData.genre {
+            metadata.genre = genre.isEmpty ? nil : genre
+        }
+        if let composer = tagData.composer {
+            metadata.composer = replaceTokens(composer, file: file)
+        }
+        if let discNumber = tagData.discNumber {
+            metadata.discNumber = discNumber.isEmpty ? nil : Int(discNumber)
+        }
+        applyAlbumArtEdits(to: metadata)
     }
 
-    func id3Frame(_ value: String,
-                  referencing file: FSFile?) -> ID3FrameWithStringContent {
-        if let file = file {
-            return ID3FrameWithStringContent(content: replaceTokens(value, file: file))
-        } else {
-            return ID3FrameWithStringContent(content: value)
+    private func applyAlbumArtEdits(to metadata: AudioMetadata) {
+        if let newArtData = tagData.albumArt,
+           let sanitized = sanitizedImageData(newArtData) {
+            metadata.removeAttachedPicturesOfType(.frontCover)
+            metadata.attachPicture(AttachedPicture(imageData: sanitized, type: .frontCover))
+        } else if isAlbumArtRemoved {
+            metadata.removeAttachedPicturesOfType(.frontCover)
         }
     }
 
-    func id3Frame(_ value: Int, total: Int?) -> ID3FramePartOfTotal {
-        return ID3FramePartOfTotal(part: value, total: total)
-    }
-
-    func id3Frame(_ value: String, identifier: ID3Genre?) -> ID3FrameGenre {
-        return ID3FrameGenre(genre: identifier, description: value)
-    }
-
-    func id3Frame(_ data: Data?, type: ID3PictureType) -> ID3FrameAttachedPicture? {
-        if let data = data,
-           let image = UIImage(data: data) {
-            if let pngData = image.pngData() {
-                return ID3FrameAttachedPicture(picture: pngData,
-                                               type: type,
-                                               format: .png)
-            } else if let jpgData = image.jpegData(compressionQuality: 1.0) {
-                return ID3FrameAttachedPicture(picture: jpgData,
-                                               type: type,
-                                               format: .jpeg)
-            }
+    private func sanitizedImageData(_ data: Data) -> Data? {
+        guard let image = UIImage(data: data) else { return nil }
+        if let pngData = image.pngData() {
+            return pngData
         }
-        return nil
+        return image.jpegData(compressionQuality: 1.0)
     }
 
     func replaceTokens(_ original: String, file: FSFile) -> String {
         var newString = original
-        let componentsDash = file.name
-            .replacingOccurrences(of: ".mp3", with: "")
+        let nameWithoutExtension = (file.name as NSString).deletingPathExtension
+        let componentsDash = nameWithoutExtension
             .components(separatedBy: "-").map { string in
-            string.trimmingCharacters(in: .whitespaces)
-        }
+                string.trimmingCharacters(in: .whitespaces)
+            }
         let tokens: [String: String] = [
-            "fileName": file.name,
+            "fileName": nameWithoutExtension,
             "splitFront": componentsDash[0],
             "splitBack": componentsDash.count >= 2 ? componentsDash[1] : ""
         ]
@@ -425,7 +297,6 @@ struct TagEditorView: View {
     }
 
 }
-// swiftlint:enable type_body_length
 
 struct SaveButtonStyleModifier: ViewModifier {
     func body(content: Content) -> some View {

--- a/Tunetag/Views/Tag Editor/TipSection.swift
+++ b/Tunetag/Views/Tag Editor/TipSection.swift
@@ -5,7 +5,6 @@
 //  Created by シン・ジャスティン on 2023/09/10.
 //
 
-import Komponents
 import SwiftUI
 
 struct TipSection: View {


### PR DESCRIPTION
## Summary

- Replaces ID3TagEditor with [SFBAudioEngine](https://github.com/sbooth/SFBAudioEngine) 0.12.1, which supports a much wider set of audio formats for tag editing.
- Tag reading and writing now go through `AudioFile` / `AudioMetadata` instead of `ID3TagEditor` / `ID3TagContentReader` / `ID32v3TagBuilder`.
- File picker is broadened to `UTType.audio`; picked files are filtered against `AudioFile.handlesPaths(withExtension:)` so only formats SFBAudioEngine actually understands are loaded.
- Token replacement (`%fileName%`, `%splitFront%`, `%splitBack%`) now strips any path extension instead of being hard-coded to `.mp3`.
- `Info.plist` document types and `FSFile`'s `Transferable` content type are widened from "MP3 only" to public audio UTIs.
- `MARKETING_VERSION` bumped from `1.4.1` to `2.0`.
- License attribution and README updated to reflect the new dependency and broader format support.

## Newly supported formats (via SFBAudioEngine)

MP3, M4A/MP4, FLAC, Ogg Vorbis / Opus / Speex / FLAC, WAV, AIFF, Monkey's Audio (APE), Musepack, WavPack, Shorten, True Audio, DSDIFF, DSF, plus tracker module formats — in addition to the previously-supported MP3.

## Notes on behavior

- The previous "build a fresh ID3v2.3 tag from scratch on every save" flow has been replaced with "mutate the file's existing metadata in place." Untouched fields are now preserved by the underlying library rather than copied through manually, which simplifies the save path considerably.
- The AVFoundation album-art fallback in `TagTyped` was removed — SFBAudioEngine reads attached pictures natively for every supported format.
- The Save retry path (`initializeTag` → `saveTagData(..., retriesWhenFailed: false)`) was specific to ID3TagEditor's quirk of needing a pre-existing tag to write into; SFBAudioEngine writes new metadata to tag-less files directly, so the retry was dropped.

## Test plan

- [ ] Open the project in Xcode, let SPM resolve `SFBAudioEngine` 0.12.1, and confirm a clean build.
- [ ] Pick a single MP3 in the document browser, verify all existing tag fields and album art read correctly, edit a few fields, save, and re-open to confirm the changes were written.
- [ ] Pick multiple MP3s with differing tag values and confirm batch edit still shows the "Keep existing" placeholder for differing fields and only writes fields you've explicitly set.
- [ ] Pick an M4A, FLAC, and OGG file (separately) and verify reading/editing/saving works end-to-end.
- [ ] Toggle album art: select a new image, save, re-open; remove album art, save, re-open.
- [ ] Verify the file picker now lets you select non-MP3 audio files, and that picking a file SFBAudioEngine doesn't support shows the "no audio files" alert instead of crashing.

https://claude.ai/code/session_011BbDFvxnREk95Ac8nThPvg

---
_Generated by [Claude Code](https://claude.ai/code/session_011BbDFvxnREk95Ac8nThPvg)_